### PR TITLE
Reduce false positives: Amplitude, placeholder, HTTP namespace URIs

### DIFF
--- a/internal/codescan/rules.go
+++ b/internal/codescan/rules.go
@@ -95,7 +95,8 @@ func AllRules() []Rule {
 			fix:       "Implement ATT prompt before any tracking. Add NSUserTrackingUsageDescription to Info.plist.",
 			languages: []string{"swift", "objc", "typescript", "javascript"},
 			patterns: []*regexp.Regexp{
-				regexp.MustCompile(`(?i)(firebase.*analytics|google.*analytics|facebook.*sdk|fbsdk|adjust.*sdk|appsflyer|amplitude|mixpanel)`),
+				regexp.MustCompile(`(?i)(firebase.*analytics|google.*analytics|facebook.*sdk|fbsdk|adjust.*sdk|appsflyer|mixpanel)`),
+			regexp.MustCompile(`(?i)(import\s+Amplitude|AmplitudeSwift|amplitude\.init|Amplitude\.instance|amplitude-js|@amplitude/)`),
 				regexp.MustCompile(`(?i)(import.*@segment/|analytics-react-native|SegmentAnalytics|createClient.*writeKey)`),
 			},
 			antiPatterns: []*regexp.Regexp{
@@ -182,6 +183,9 @@ func AllRules() []Rule {
 				regexp.MustCompile("(?i)`[^`]*\\b(lorem ipsum|placeholder|coming soon|under construction|todo|tbd)\\b[^`]*`"),
 				regexp.MustCompile(`(?i)\b(lorem ipsum|placeholder|coming soon|under construction|todo|tbd)\b`), // bare text (JSX content)
 			},
+			ignorePatterns: []*regexp.Regexp{
+				regexp.MustCompile(`(?i)(func\s+placeholder\s*\(|\.placeholder\s*[:=]|placeholder\s*[:=]\s*[A-Z]|placeholder\s*\(in\s*context)`), // Swift/WidgetKit protocol methods and property assignments
+			},
 		},
 		&PatternRule{
 			id:        "console-log",
@@ -225,6 +229,7 @@ func AllRules() []Rule {
 			},
 			ignorePatterns: []*regexp.Regexp{
 				regexp.MustCompile(`(?i)(localhost|127\.0\.0\.1|0\.0\.0\.0|http://example)`),
+				regexp.MustCompile(`(?i)(w3\.org|xmlns|DTD|doctype)`), // XML/SVG namespace URIs and DTD references are identifiers, not network requests
 			},
 		},
 		&PatternRule{

--- a/internal/privacy/scanner.go
+++ b/internal/privacy/scanner.go
@@ -103,7 +103,7 @@ var trackingSDKPatterns = []struct {
 	{regexp.MustCompile(`(?i)(fbsdk|facebook.*sdk)`), "Facebook SDK"},
 	{regexp.MustCompile(`(?i)adjust.*sdk`), "Adjust SDK"},
 	{regexp.MustCompile(`(?i)appsflyer`), "AppsFlyer"},
-	{regexp.MustCompile(`(?i)(amplitude)`), "Amplitude"},
+	{regexp.MustCompile(`(?i)(import\s+Amplitude|AmplitudeSwift|amplitude\.init|Amplitude\.instance|amplitude-js|@amplitude/)`), "Amplitude"},
 	{regexp.MustCompile(`(?i)(mixpanel)`), "Mixpanel"},
 	{regexp.MustCompile(`(?i)(@segment/|analytics-react-native)`), "Segment"},
 	{regexp.MustCompile(`(?i)(branch\.io|react-native-branch)`), "Branch"},


### PR DESCRIPTION
## Summary
- **Amplitude SDK detection**: Replaced bare `(?i)(amplitude)` regex with SDK-specific patterns (`import Amplitude`, `Amplitude.instance`, `@amplitude/`, etc.). The word "amplitude" is a common math/physics term (e.g. `let amplitude: CGFloat = 8` for wave rendering) and was causing false positives on variable names and comments.
- **Placeholder content detection**: Added ignore patterns for Swift/WidgetKit protocol method signatures like `func placeholder(in context:)`, which is a required `AppIntentTimelineProvider` conformance — not actual placeholder text.
- **Insecure HTTP URL detection**: Added `w3.org`, `xmlns`, `DTD`, and `doctype` to the ignore list. XML/SVG namespace URIs like `http://www.w3.org/2000/svg` are spec-defined identifiers, not network requests, and are unaffected by App Transport Security.

## Context
All three false positives were encountered while running `greenlight preflight` on a SwiftUI iOS app with WidgetKit extensions and embedded HTML5 games using inline SVG.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] Verify Amplitude SDK is still detected when actually imported (e.g. `import Amplitude`)
- [ ] Verify `func placeholder(in context:)` no longer triggers, but `"placeholder text"` in strings still does
- [ ] Verify `http://www.w3.org/2000/svg` no longer triggers, but `http://example-api.com/data` still does
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refines detection patterns for Amplitude SDK, placeholder content, and HTTP URLs to reduce false positives in code scanning.
> 
>   - **Amplitude SDK Detection**:
>     - Replaced generic `(?i)(amplitude)` regex with specific patterns like `import Amplitude`, `Amplitude.instance`, `@amplitude/` in `rules.go` and `scanner.go`.
>   - **Placeholder Content Detection**:
>     - Added ignore patterns for Swift/WidgetKit methods like `func placeholder(in context:)` in `rules.go`.
>   - **HTTP URL Detection**:
>     - Added `w3.org`, `xmlns`, `DTD`, and `doctype` to ignore list in `rules.go` for XML/SVG namespace URIs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RevylAI%2Fgreenlight&utm_source=github&utm_medium=referral)<sup> for d4001713a4452b1526119511526ed323b1507321. You can [customize](https://app.ellipsis.dev/RevylAI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->