### PR TITLE
Add Codex-native skill package

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,23 @@ Claude will:
 3. Fix each issue (CRITICAL first, then WARN, then INFO)
 4. Re-run and repeat until GREENLIT
 
+## Codex Skill
+
+Greenlight includes a Codex-native skill package at `codex-skill/`.
+
+### Setup
+
+```bash
+mkdir -p ~/.codex/skills/app-store-preflight-compliance
+cp -R codex-skill/* ~/.codex/skills/app-store-preflight-compliance/
+```
+
+Then in Codex, invoke:
+
+```text
+Use $app-store-preflight-compliance to run Greenlight preflight and fix all findings until GREENLIT.
+```
+
 ## Architecture
 
 ```

--- a/codex-skill/SKILL.md
+++ b/codex-skill/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: app-store-preflight-compliance
+description: Pre-submission compliance scanner workflow for Apple App Store apps. Use when reviewing iOS, macOS, tvOS, watchOS, or visionOS projects (Swift, Objective-C, React Native, Expo) for App Store rejection risks, submission readiness, privacy compliance, or guideline violations.
+---
+
+# App Store Preflight Compliance
+
+Run Greenlight checks, fix findings, and repeat until the project reaches GREENLIT status.
+
+## Workflow
+
+1. Run `greenlight preflight` at the project root.
+2. Triage findings by severity (`CRITICAL`, then `WARN`, then `INFO`).
+3. Apply concrete code/configuration fixes.
+4. Re-run and continue until no `CRITICAL` findings remain.
+
+## Step 1: Run Scan
+
+```bash
+greenlight preflight .
+```
+
+If an IPA is available:
+
+```bash
+greenlight preflight . --ipa /path/to/build.ipa
+```
+
+If `greenlight` is missing, install it:
+
+```bash
+# Homebrew (macOS)
+brew install revylai/tap/greenlight
+
+# Go
+go install github.com/RevylAI/greenlight/cmd/greenlight@latest
+
+# Build from source
+git clone https://github.com/RevylAI/greenlight.git
+cd greenlight && make build
+```
+
+## Step 2: Fix Findings
+
+Fix in order:
+
+1. `CRITICAL`: must fix before submission.
+2. `WARN`: high rejection risk, strongly recommended to fix.
+3. `INFO`: best-practice improvements.
+
+Common fixes:
+
+- Move hardcoded secrets to environment variables.
+- Replace external payment flows for digital goods with StoreKit/IAP.
+- Add Sign in with Apple when social login exists.
+- Add account deletion when account creation exists.
+- Remove references to competing platforms.
+- Replace placeholder text (`Lorem ipsum`, `TBD`, `Coming soon`).
+- Rewrite vague purpose strings with concrete app behavior.
+- Replace hardcoded IPs with hostnames.
+- Replace `http://` URLs with `https://`.
+- Remove debug logs or gate them behind development flags.
+- Add missing privacy policy URL and required App Store metadata.
+
+## Step 3: Re-Run Until GREENLIT
+
+```bash
+greenlight preflight .
+```
+
+Continue until output reports GREENLIT (zero `CRITICAL` findings).
+
+## Useful Commands
+
+```bash
+greenlight codescan .
+greenlight privacy .
+greenlight ipa /path/to/build.ipa
+greenlight scan --app-id <ID>
+greenlight guidelines search "privacy"
+```
+
+## Attribution
+
+Original project and workflow: [RevylAI/greenlight](https://github.com/RevylAI/greenlight).
+
+Credit to Lanseer and the Revyl team for creating Greenlight. This package is a Codex-native adaptation for the same workflow.

--- a/codex-skill/agents/openai.yaml
+++ b/codex-skill/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "App Store Preflight Compliance"
+  short_description: "Apple App Store preflight compliance workflow"
+  default_prompt: "Use $app-store-preflight-compliance to run Greenlight preflight, fix compliance issues, and rerun until GREENLIT."


### PR DESCRIPTION
## Summary
- add a Codex-native Greenlight skill package under `codex-skill/`
- include `SKILL.md` + `agents/openai.yaml` for direct Codex use
- add a short README section with copy/paste setup and invocation

## Attribution
- this package adapts the existing Greenlight workflow for Codex
- credit to Lanseer and the Revyl team for the original Greenlight project and workflow

## Review checklist
- verify `codex-skill/SKILL.md` reflects current Greenlight usage
- verify `codex-skill/agents/openai.yaml` metadata and `$app-store-preflight-compliance` invocation
- follow README `Codex Skill` setup steps and confirm skill loads in Codex

## Validation
- local skill validation: `quick_validate.py codex-skill` -> `Skill is valid!`
