### PR TITLE
Add runtime flow validation via Revyl CLI (greenlight verify)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 **Know before you submit.** Pre-submission compliance scanner for the Apple App Store.
 
-Greenlight scans your app — source code, privacy manifests, IPA binaries, and App Store Connect metadata — against Apple's Review Guidelines, catching rejection risks before Apple does. And with `greenlight verify`, it goes a step further: it validates your flow-dependent guidelines (account deletion, restore purchases, Sign in with Apple) on a **real device** via [Revyl](https://revyl.com) — catching broken flows that static analysis structurally can't.
+Greenlight scans your app — source code, privacy manifests, IPA binaries, and App Store Connect metadata — against Apple's Review Guidelines, catching rejection risks before Apple does. Fully offline, no account, runs in under a second.
+
+> **Optional runtime tier:** want to confirm flow-dependent guidelines (account deletion, restore purchases, Sign in with Apple) actually *work*, not just exist in source? `greenlight verify` validates them on a real device via [Revyl](https://revyl.com). It's entirely separate and opt-in — the static scanner above never needs it. See [`greenlight verify`](#greenlight-verify-path--runtime-flow-validation-via-revyl).
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Know before you submit.** Pre-submission compliance scanner for the Apple App Store.
 
-Greenlight scans your app — source code, privacy manifests, IPA binaries, and App Store Connect metadata — against Apple's Review Guidelines, catching rejection risks before Apple does.
+Greenlight scans your app — source code, privacy manifests, IPA binaries, and App Store Connect metadata — against Apple's Review Guidelines, catching rejection risks before Apple does. And with `greenlight verify`, it goes a step further: it validates your flow-dependent guidelines (account deletion, restore purchases, Sign in with Apple) on a **real device** via [Revyl](https://revyl.com) — catching broken flows that static analysis structurally can't.
 
 ## Install
 
@@ -118,6 +118,41 @@ API-based checks against your app in App Store Connect:
 - Age rating and encryption compliance
 - Content analysis (platform references, placeholders)
 
+### `greenlight verify [path]` — Runtime flow validation (via Revyl)
+
+Static checks confirm a flow **exists** in your source. `verify` confirms it **works**
+on a real device by handing flow-dependent guidelines to the [Revyl](https://revyl.com)
+CLI and running the actual flow.
+
+This catches what static analysis structurally cannot. A "Delete Account" button wired
+to nothing **passes** codescan — the string `deleteAccount` is present, so §5.1.1 is
+suppressed and you get GREENLIT — but it dead-ends at runtime, and Apple rejects it under
+§5.1.1(v). `verify` runs the flow on a device and catches it.
+
+```bash
+greenlight verify .                       # dry-run-style: shows which flows are claimed
+greenlight verify . --dry-run             # print the generated Revyl tests, no device
+greenlight verify . --build-name "My App" \
+  --var email=qa@acme.com --var password=secret   # run on a device
+greenlight verify . --build-name "My App" --flows account-deletion --os-version "iOS 26.2"
+```
+
+Flows verified (only the ones your app actually claims are run):
+
+| Flow | Guideline | What runtime proves that static can't |
+|------|-----------|----------------------------------------|
+| `account-deletion`   | §5.1.1 | The account is *actually deleted* — not that a `deleteAccount` string exists |
+| `restore-purchases`  | §3.1.1 | "Restore Purchases" does something — not a silent no-op button |
+| `sign-in-apple`      | §4.8   | The Apple sign-in sheet actually appears — not a dead control |
+
+A failed flow becomes a `BLOCK` static analysis could never produce, with a shareable
+Revyl report link as evidence.
+
+> **Note:** Unlike every other greenlight command, `verify` is **not** offline. It needs
+> the [`revyl` CLI](https://docs.revyl.com), a Revyl account (`revyl auth login`), and a
+> registered build. It's a deliberately separate, opt-in tier — run `preflight` first to
+> get GREENLIT, then `verify` before you submit.
+
 ### `greenlight guidelines` — Browse Apple's guidelines
 
 ```bash
@@ -191,6 +226,11 @@ greenlight
 ├── codescan          Code-only scanning
 ├── privacy           Privacy-only scanning
 ├── ipa               Binary-only inspection
+│
+├── verify            Runtime flow validation on a real device (via Revyl)
+│   ├── account-deletion   §5.1.1 — the account is actually deleted
+│   ├── restore-purchases  §3.1.1 — Restore Purchases isn't a no-op
+│   └── sign-in-apple      §4.8   — the Apple sign-in sheet actually appears
 │
 ├── scan              App Store Connect API checks (tiers 1-4)
 │   ├── Tier 1        Metadata & completeness

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Greenlight scans your app — source code, privacy manifests, IPA binaries, and App Store Connect metadata — against Apple's Review Guidelines, catching rejection risks before Apple does. Fully offline, no account, runs in under a second.
 
-> **Optional runtime tier:** want to confirm flow-dependent guidelines (account deletion, restore purchases, Sign in with Apple) actually *work*, not just exist in source? `greenlight verify` validates them on a real device via [Revyl](https://revyl.com). It's entirely separate and opt-in — the static scanner above never needs it. See [`greenlight verify`](#greenlight-verify-path--runtime-flow-validation-via-revyl).
+> **Optional runtime tier:** want to confirm flow-dependent guidelines (account deletion, restore purchases, Sign in with Apple) actually *work*, not just exist in source? `greenlight verify` validates them on a cloud device via [Revyl](https://revyl.com). It's entirely separate and opt-in — the static scanner above never needs it. See [`greenlight verify`](#greenlight-verify-path--runtime-flow-validation-via-revyl).
 
 ## Install
 
@@ -123,7 +123,7 @@ API-based checks against your app in App Store Connect:
 ### `greenlight verify [path]` — Runtime flow validation (via Revyl)
 
 Static checks confirm a flow **exists** in your source. `verify` confirms it **works**
-on a real device by handing flow-dependent guidelines to the [Revyl](https://revyl.com)
+on a cloud device by handing flow-dependent guidelines to the [Revyl](https://revyl.com)
 CLI and running the actual flow.
 
 This catches what static analysis structurally cannot. A "Delete Account" button wired
@@ -229,7 +229,7 @@ greenlight
 ├── privacy           Privacy-only scanning
 ├── ipa               Binary-only inspection
 │
-├── verify            Runtime flow validation on a real device (via Revyl)
+├── verify            Runtime flow validation on a cloud device (via Revyl)
 │   ├── account-deletion   §5.1.1 — the account is actually deleted
 │   ├── restore-purchases  §3.1.1 — Restore Purchases isn't a no-op
 │   └── sign-in-apple      §4.8   — the Apple sign-in sheet actually appears
@@ -275,4 +275,4 @@ greenlight scan --app-id $APP_ID --format junit --output greenlight.xml
 
 Greenlight catches App Store rejections. [Revyl](https://revyl.com) catches bugs.
 
-The mobile reliability platform. AI-powered testing for mobile apps — write tests in natural language, run them on real devices.
+The mobile reliability platform. AI-powered testing for mobile apps — write tests in natural language, run them on cloud devices.

--- a/README.md
+++ b/README.md
@@ -132,8 +132,7 @@ suppressed and you get GREENLIT — but it dead-ends at runtime, and Apple rejec
 §5.1.1(v). `verify` runs the flow on a device and catches it.
 
 ```bash
-greenlight verify .                       # dry-run-style: shows which flows are claimed
-greenlight verify . --dry-run             # print the generated Revyl tests, no device
+greenlight verify . --dry-run             # show which flows are claimed + the generated tests, no device
 greenlight verify . --build-name "My App" \
   --var email=qa@acme.com --var password=secret   # run on a device
 greenlight verify . --build-name "My App" --flows account-deletion --os-version "iOS 26.2"

--- a/SKILL.md
+++ b/SKILL.md
@@ -78,6 +78,39 @@ greenlight preflight .
 
 The goal is always: **zero CRITICAL findings = GREENLIT status.**
 
+## Step 4 (optional): Validate flow-dependent guidelines at runtime
+
+GREENLIT means the *static* checks pass — but some guidelines can only be confirmed by
+running the flow. Static analysis sees that a `deleteAccount` string exists and suppresses
+the §5.1.1 warning; it cannot see that the button is wired to nothing. Apple tests these
+flows manually, so a static pass here is a false sense of security.
+
+If the project claims a flow-dependent feature (account creation, in-app purchases, or
+social login), validate it on a real device with `greenlight verify`:
+
+```bash
+# See which flows the app claims and the exact tests that would run — no device needed:
+greenlight verify . --dry-run
+
+# Run them on a real device (needs the revyl CLI + `revyl auth login` + a registered build):
+greenlight verify . --build-name "<your Revyl build>" \
+  --var email=<test account> --var password=<test password>
+```
+
+`verify` runs each claimed flow on-device via Revyl and reports:
+- **VERIFIED** — the flow works.
+- **FAILED** — the flow passed static analysis but broke at runtime (e.g. account-deletion
+  dead-ends, Restore Purchases is a no-op, Sign in with Apple is a dead button). Fix the
+  wiring — not just the presence of the string — and re-run.
+- **SETUP** — could not run (not authenticated, no build, no device). Resolve and retry.
+
+Treat a FAILED flow exactly like a CRITICAL: it will get the app rejected. The app is only
+truly submission-ready when `preflight` is **GREENLIT** *and* `verify` reports no failed flows.
+
+> `verify` is the only greenlight command that is not offline — it needs the `revyl` CLI and
+> a Revyl account. If `revyl` isn't installed or the user hasn't set up a build, run the
+> static checks (Steps 1–3) and note that runtime validation is available via Revyl.
+
 ## Other CLI Commands
 
 ```bash
@@ -85,6 +118,7 @@ greenlight codescan .                      # Code-only scan
 greenlight privacy .                       # Privacy manifest scan
 greenlight ipa /path/to/build.ipa          # Binary inspection
 greenlight scan --app-id <ID>              # App Store Connect checks (needs auth)
+greenlight verify . --dry-run              # Runtime flow validation via Revyl (needs revyl CLI)
 greenlight guidelines search "privacy"     # Search Apple guidelines
 ```
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -95,6 +95,12 @@ greenlight verify . --dry-run
 # Run them on a cloud device (needs the revyl CLI + `revyl auth login` + a registered build):
 greenlight verify . --build-name "<your Revyl build>" \
   --var email=<test account> --var password=<test password>
+
+# Have a local build that isn't on Revyl yet? Upload it as part of the run with
+# --artifact. Revyl runs on cloud simulators, so pass a simulator .app (iOS) or
+# an .apk (Android) — NOT a device .ipa. A new --build-name registers a new app.
+greenlight verify . --build-name "<your Revyl build>" --artifact ./build/MyApp.app \
+  --var email=<test account> --var password=<test password>
 ```
 
 `verify` runs each claimed flow on-device via Revyl and reports:
@@ -103,6 +109,8 @@ greenlight verify . --build-name "<your Revyl build>" \
   dead-ends, Restore Purchases is a no-op, Sign in with Apple is a dead button). Fix the
   wiring — not just the presence of the string — and re-run.
 - **SETUP** — could not run (not authenticated, no build, no device). Resolve and retry.
+  If the build just isn't on Revyl yet but you have a local simulator `.app`/`.apk`,
+  pass it with `--artifact` to upload and run in one step.
 
 Treat a FAILED flow exactly like a CRITICAL: it will get the app rejected. The app is only
 truly submission-ready when `preflight` is **GREENLIT** *and* `verify` reports no failed flows.

--- a/SKILL.md
+++ b/SKILL.md
@@ -86,13 +86,13 @@ the §5.1.1 warning; it cannot see that the button is wired to nothing. Apple te
 flows manually, so a static pass here is a false sense of security.
 
 If the project claims a flow-dependent feature (account creation, in-app purchases, or
-social login), validate it on a real device with `greenlight verify`:
+social login), validate it on a cloud device with `greenlight verify`:
 
 ```bash
 # See which flows the app claims and the exact tests that would run — no device needed:
 greenlight verify . --dry-run
 
-# Run them on a real device (needs the revyl CLI + `revyl auth login` + a registered build):
+# Run them on a cloud device (needs the revyl CLI + `revyl auth login` + a registered build):
 greenlight verify . --build-name "<your Revyl build>" \
   --var email=<test account> --var password=<test password>
 ```

--- a/internal/cli/preflight.go
+++ b/internal/cli/preflight.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/RevylAI/greenlight/internal/codescan"
 	"github.com/RevylAI/greenlight/internal/preflight"
 	"github.com/RevylAI/greenlight/internal/verify"
 	"github.com/fatih/color"
@@ -123,16 +122,13 @@ func runPreflight(cmd *cobra.Command, args []string) error {
 
 	isJSON := strings.ToLower(preflightFormat) == "json"
 
-	// Default path: static only (offline, zero-account, instant).
+	// Default path: static only — offline, zero-account, instant, and complete
+	// on its own. No Revyl pitch here; the runtime tier is strictly opt-in.
 	if !preflightVerify {
 		if isJSON {
 			return writePreflightJSON(output, result)
 		}
-		if err := writePreflightTerminal(output, result); err != nil {
-			return err
-		}
-		printRuntimeNudge(output, path)
-		return nil
+		return writePreflightTerminal(output, result)
 	}
 
 	// --verify: the static cycle runs, THEN Revyl runs the flows on a device.
@@ -162,36 +158,6 @@ func runPreflight(cmd *cobra.Command, args []string) error {
 	fmt.Fprintln(output)
 	writeVerifyTerminal(output, vres)
 	return nil
-}
-
-// printRuntimeNudge is the soft upsell: when the app claims a flow-dependent
-// feature, static analysis can confirm the code exists but not that the flow
-// works — point the user at the runtime tier.
-func printRuntimeNudge(w *os.File, path string) {
-	claims, err := codescan.DetectClaims(path)
-	if err != nil {
-		return
-	}
-	var feats []string
-	if claims.AccountCreation {
-		feats = append(feats, "account deletion")
-	}
-	if claims.IAP {
-		feats = append(feats, "restore purchases")
-	}
-	if claims.SocialLogin {
-		feats = append(feats, "Sign in with Apple")
-	}
-	if len(feats) == 0 {
-		return
-	}
-	yellow := color.New(color.FgYellow)
-	yellow.Fprintf(w, "  ⚠ Flow-dependent guidelines detected (%s).\n", strings.Join(feats, ", "))
-	dim.Fprintln(w, "    Static analysis can confirm these exist in code — not that they actually work.")
-	dim.Fprintln(w, "    Apple tests these flows manually. Validate them on a real device:")
-	fmt.Fprint(w, "    ")
-	purple.Fprintln(w, "greenlight verify . --build-name \"<your Revyl build>\"")
-	fmt.Fprintln(w)
 }
 
 func writePreflightTerminal(w *os.File, result *preflight.Result) error {

--- a/internal/cli/preflight.go
+++ b/internal/cli/preflight.go
@@ -87,18 +87,19 @@ func runPreflight(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Banner
-	purple.Println("\n  greenlight preflight — every check, one command, zero uploads.")
-	fmt.Printf("  Project: %s\n", path)
-	if preflightIPA != "" {
-		fmt.Printf("  IPA:     %s\n", preflightIPA)
+	// Banner (suppressed for --format json so stdout stays valid JSON).
+	if strings.ToLower(preflightFormat) != "json" {
+		purple.Println("\n  greenlight preflight — every check, one command, zero uploads.")
+		fmt.Printf("  Project: %s\n", path)
+		if preflightIPA != "" {
+			fmt.Printf("  IPA:     %s\n", preflightIPA)
+		}
+		scanners := []string{"metadata", "codescan", "privacy"}
+		if preflightIPA != "" {
+			scanners = append(scanners, "ipa")
+		}
+		fmt.Printf("  Checks:  %s\n\n", strings.Join(scanners, " + "))
 	}
-
-	scanners := []string{"metadata", "codescan", "privacy"}
-	if preflightIPA != "" {
-		scanners = append(scanners, "ipa")
-	}
-	fmt.Printf("  Checks:  %s\n\n", strings.Join(scanners, " + "))
 
 	// Run all checks
 	start := time.Now()

--- a/internal/cli/preflight.go
+++ b/internal/cli/preflight.go
@@ -8,8 +8,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/fatih/color"
+	"github.com/RevylAI/greenlight/internal/codescan"
 	"github.com/RevylAI/greenlight/internal/preflight"
+	"github.com/RevylAI/greenlight/internal/verify"
+	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
 
@@ -17,6 +19,14 @@ var (
 	preflightIPA    string
 	preflightFormat string
 	preflightOutput string
+
+	// Runtime tier (--verify): after the static checks, hand flow-dependent
+	// guidelines to Revyl to validate on a real device.
+	preflightVerify      bool
+	preflightBuildName   string
+	preflightVars        map[string]string
+	preflightDeviceModel string
+	preflightOSVersion   string
 )
 
 var preflightCmd = &cobra.Command{
@@ -31,10 +41,15 @@ Combines:
   • Metadata scan — app.json / Info.plist completeness, icons, version, bundle ID
   • IPA inspect   — binary analysis (if --ipa is provided)
 
+Add --verify to continue past the static checks and validate your flow-dependent
+guidelines (account deletion, restore purchases, Sign in with Apple) on a REAL
+device via Revyl — catching broken flows static analysis structurally can't.
+
 Usage:
   greenlight preflight .
   greenlight preflight ./my-app --ipa build.ipa
-  greenlight preflight /path/to/project --format json`,
+  greenlight preflight /path/to/project --format json
+  greenlight preflight . --verify --build-name "My App" --var email=qa@acme.com --var password=secret`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runPreflight,
 }
@@ -43,6 +58,11 @@ func init() {
 	preflightCmd.Flags().StringVar(&preflightIPA, "ipa", "", "path to .ipa file for binary inspection")
 	preflightCmd.Flags().StringVar(&preflightFormat, "format", "terminal", "output format: terminal, json")
 	preflightCmd.Flags().StringVar(&preflightOutput, "output", "", "write report to file (stdout if omitted)")
+	preflightCmd.Flags().BoolVar(&preflightVerify, "verify", false, "after static checks, validate flow-dependent guidelines on a real device via Revyl")
+	preflightCmd.Flags().StringVar(&preflightBuildName, "build-name", "", "Revyl build/app name (for --verify)")
+	preflightCmd.Flags().StringToStringVar(&preflightVars, "var", nil, "test variable for --verify, e.g. --var email=qa@acme.com (repeatable)")
+	preflightCmd.Flags().StringVar(&preflightDeviceModel, "device-model", "", "device model for --verify, e.g. \"iPhone 16\"")
+	preflightCmd.Flags().StringVar(&preflightOSVersion, "os-version", "", "OS version for --verify, e.g. \"iOS 26.2\"")
 	rootCmd.AddCommand(preflightCmd)
 }
 
@@ -101,12 +121,77 @@ func runPreflight(cmd *cobra.Command, args []string) error {
 		output = os.Stdout
 	}
 
-	switch strings.ToLower(preflightFormat) {
-	case "json":
-		return writePreflightJSON(output, result)
-	default:
-		return writePreflightTerminal(output, result)
+	isJSON := strings.ToLower(preflightFormat) == "json"
+
+	// Default path: static only (offline, zero-account, instant).
+	if !preflightVerify {
+		if isJSON {
+			return writePreflightJSON(output, result)
+		}
+		if err := writePreflightTerminal(output, result); err != nil {
+			return err
+		}
+		printRuntimeNudge(output, path)
+		return nil
 	}
+
+	// --verify: the static cycle runs, THEN Revyl runs the flows on a device.
+	vstart := time.Now()
+	vres, verr := verify.Run(verify.Config{
+		ProjectPath: path,
+		BuildName:   preflightBuildName,
+		Platform:    "ios",
+		Vars:        preflightVars,
+		DeviceModel: preflightDeviceModel,
+		OSVersion:   preflightOSVersion,
+	})
+	if verr != nil {
+		return fmt.Errorf("runtime validation failed: %w", verr)
+	}
+	vres.Elapsed = time.Since(vstart)
+
+	if isJSON {
+		return writeCombinedJSON(output, result, vres)
+	}
+
+	if err := writePreflightTerminal(output, result); err != nil {
+		return err
+	}
+	fmt.Fprintln(output)
+	purple.Fprintln(output, "  → Static checks done. Now validating the flows actually WORK, on a real device…")
+	fmt.Fprintln(output)
+	writeVerifyTerminal(output, vres)
+	return nil
+}
+
+// printRuntimeNudge is the soft upsell: when the app claims a flow-dependent
+// feature, static analysis can confirm the code exists but not that the flow
+// works — point the user at the runtime tier.
+func printRuntimeNudge(w *os.File, path string) {
+	claims, err := codescan.DetectClaims(path)
+	if err != nil {
+		return
+	}
+	var feats []string
+	if claims.AccountCreation {
+		feats = append(feats, "account deletion")
+	}
+	if claims.IAP {
+		feats = append(feats, "restore purchases")
+	}
+	if claims.SocialLogin {
+		feats = append(feats, "Sign in with Apple")
+	}
+	if len(feats) == 0 {
+		return
+	}
+	yellow := color.New(color.FgYellow)
+	yellow.Fprintf(w, "  ⚠ Flow-dependent guidelines detected (%s).\n", strings.Join(feats, ", "))
+	dim.Fprintln(w, "    Static analysis can confirm these exist in code — not that they actually work.")
+	dim.Fprintln(w, "    Apple tests these flows manually. Validate them on a real device:")
+	fmt.Fprint(w, "    ")
+	purple.Fprintln(w, "greenlight verify . --build-name \"<your Revyl build>\"")
+	fmt.Fprintln(w)
 }
 
 func writePreflightTerminal(w *os.File, result *preflight.Result) error {
@@ -304,8 +389,8 @@ func printPreflightFooter(w *os.File, result *preflight.Result) {
 	fmt.Fprintln(w)
 }
 
-func writePreflightJSON(w *os.File, result *preflight.Result) error {
-	output := struct {
+func preflightJSONObject(result *preflight.Result) interface{} {
+	return struct {
 		ProjectPath    string              `json:"project_path"`
 		IPAPath        string              `json:"ipa_path,omitempty"`
 		AppName        string              `json:"app_name,omitempty"`
@@ -328,8 +413,25 @@ func writePreflightJSON(w *os.File, result *preflight.Result) error {
 		Summary:        result.Summary,
 		Elapsed:        result.Elapsed.Round(time.Millisecond).String(),
 	}
+}
 
+func writePreflightJSON(w *os.File, result *preflight.Result) error {
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
-	return enc.Encode(output)
+	return enc.Encode(preflightJSONObject(result))
+}
+
+// writeCombinedJSON emits the static result and the runtime (Revyl) result
+// together under one object — used when --verify is chained with --format json.
+func writeCombinedJSON(w *os.File, result *preflight.Result, vres *verify.Result) error {
+	combined := struct {
+		Static  interface{} `json:"static"`
+		Runtime interface{} `json:"runtime"`
+	}{
+		Static:  preflightJSONObject(result),
+		Runtime: verifyJSONObject(vres),
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(combined)
 }

--- a/internal/cli/preflight.go
+++ b/internal/cli/preflight.go
@@ -20,7 +20,7 @@ var (
 	preflightOutput string
 
 	// Runtime tier (--verify): after the static checks, hand flow-dependent
-	// guidelines to Revyl to validate on a real device.
+	// guidelines to Revyl to validate on a cloud device.
 	preflightVerify      bool
 	preflightBuildName   string
 	preflightVars        map[string]string
@@ -57,7 +57,7 @@ func init() {
 	preflightCmd.Flags().StringVar(&preflightIPA, "ipa", "", "path to .ipa file for binary inspection")
 	preflightCmd.Flags().StringVar(&preflightFormat, "format", "terminal", "output format: terminal, json")
 	preflightCmd.Flags().StringVar(&preflightOutput, "output", "", "write report to file (stdout if omitted)")
-	preflightCmd.Flags().BoolVar(&preflightVerify, "verify", false, "after static checks, validate flow-dependent guidelines on a real device via Revyl")
+	preflightCmd.Flags().BoolVar(&preflightVerify, "verify", false, "after static checks, validate flow-dependent guidelines on a cloud device via Revyl")
 	preflightCmd.Flags().StringVar(&preflightBuildName, "build-name", "", "Revyl build/app name (for --verify)")
 	preflightCmd.Flags().StringToStringVar(&preflightVars, "var", nil, "test variable for --verify, e.g. --var email=qa@acme.com (repeatable)")
 	preflightCmd.Flags().StringVar(&preflightDeviceModel, "device-model", "", "device model for --verify, e.g. \"iPhone 16\"")
@@ -123,12 +123,18 @@ func runPreflight(cmd *cobra.Command, args []string) error {
 	isJSON := strings.ToLower(preflightFormat) == "json"
 
 	// Default path: static only — offline, zero-account, instant, and complete
-	// on its own. No Revyl pitch here; the runtime tier is strictly opt-in.
+	// on its own. The runtime tier is strictly opt-in; we only leave a light tip.
 	if !preflightVerify {
 		if isJSON {
 			return writePreflightJSON(output, result)
 		}
-		return writePreflightTerminal(output, result)
+		if err := writePreflightTerminal(output, result); err != nil {
+			return err
+		}
+		dim.Fprintln(output, "  Tip → 'greenlight preflight --verify' also runs your sign-in, purchase, and")
+		dim.Fprintln(output, "        account-deletion flows on a Revyl cloud device to confirm they work.")
+		fmt.Fprintln(output)
+		return nil
 	}
 
 	// --verify: the static cycle runs, THEN Revyl runs the flows on a device.
@@ -154,7 +160,7 @@ func runPreflight(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	fmt.Fprintln(output)
-	purple.Fprintln(output, "  → Static checks done. Now validating the flows actually WORK, on a real device…")
+	purple.Fprintln(output, "  → Static checks done. Now validating the flows actually WORK, on a cloud device…")
 	fmt.Fprintln(output)
 	writeVerifyTerminal(output, vres)
 	return nil

--- a/internal/cli/preflight.go
+++ b/internal/cli/preflight.go
@@ -23,7 +23,7 @@ var (
 	// guidelines to Revyl to validate on a cloud device.
 	preflightVerify      bool
 	preflightBuildName   string
-	preflightVars        map[string]string
+	preflightVarsRaw     []string
 	preflightDeviceModel string
 	preflightOSVersion   string
 )
@@ -59,7 +59,7 @@ func init() {
 	preflightCmd.Flags().StringVar(&preflightOutput, "output", "", "write report to file (stdout if omitted)")
 	preflightCmd.Flags().BoolVar(&preflightVerify, "verify", false, "after static checks, validate flow-dependent guidelines on a cloud device via Revyl")
 	preflightCmd.Flags().StringVar(&preflightBuildName, "build-name", "", "Revyl build/app name (for --verify)")
-	preflightCmd.Flags().StringToStringVar(&preflightVars, "var", nil, "test variable for --verify, e.g. --var email=qa@acme.com (repeatable)")
+	preflightCmd.Flags().StringArrayVar(&preflightVarsRaw, "var", nil, "test variable for --verify, e.g. --var email=qa@acme.com (repeatable)")
 	preflightCmd.Flags().StringVar(&preflightDeviceModel, "device-model", "", "device model for --verify, e.g. \"iPhone 16\"")
 	preflightCmd.Flags().StringVar(&preflightOSVersion, "os-version", "", "OS version for --verify, e.g. \"iOS 26.2\"")
 	rootCmd.AddCommand(preflightCmd)
@@ -143,7 +143,7 @@ func runPreflight(cmd *cobra.Command, args []string) error {
 		ProjectPath: path,
 		BuildName:   preflightBuildName,
 		Platform:    "ios",
-		Vars:        preflightVars,
+		Vars:        parseVars(preflightVarsRaw),
 		DeviceModel: preflightDeviceModel,
 		OSVersion:   preflightOSVersion,
 	})

--- a/internal/cli/preflight.go
+++ b/internal/cli/preflight.go
@@ -23,6 +23,7 @@ var (
 	// guidelines to Revyl to validate on a cloud device.
 	preflightVerify      bool
 	preflightBuildName   string
+	preflightArtifact    string
 	preflightVarsRaw     []string
 	preflightDeviceModel string
 	preflightOSVersion   string
@@ -59,6 +60,7 @@ func init() {
 	preflightCmd.Flags().StringVar(&preflightOutput, "output", "", "write report to file (stdout if omitted)")
 	preflightCmd.Flags().BoolVar(&preflightVerify, "verify", false, "after static checks, validate flow-dependent guidelines on a cloud device via Revyl")
 	preflightCmd.Flags().StringVar(&preflightBuildName, "build-name", "", "Revyl build/app name (for --verify)")
+	preflightCmd.Flags().StringVar(&preflightArtifact, "artifact", "", "upload a prebuilt .app (iOS sim) or .apk (Android) to Revyl before --verify runs")
 	preflightCmd.Flags().StringArrayVar(&preflightVarsRaw, "var", nil, "test variable for --verify, e.g. --var email=qa@acme.com (repeatable)")
 	preflightCmd.Flags().StringVar(&preflightDeviceModel, "device-model", "", "device model for --verify, e.g. \"iPhone 16\"")
 	preflightCmd.Flags().StringVar(&preflightOSVersion, "os-version", "", "OS version for --verify, e.g. \"iOS 26.2\"")
@@ -139,6 +141,16 @@ func runPreflight(cmd *cobra.Command, args []string) error {
 	}
 
 	// --verify: the static cycle runs, THEN Revyl runs the flows on a device.
+	if preflightArtifact != "" {
+		if preflightBuildName == "" {
+			return fmt.Errorf("--artifact requires --build-name (to name or match the Revyl app for the uploaded build)")
+		}
+		// preflight's runtime tier is iOS-only (App Store), matching the
+		// hardcoded Platform: "ios" passed to verify.Run below.
+		if err := verify.ValidateArtifact(preflightArtifact, "ios"); err != nil {
+			return err
+		}
+	}
 	vstart := time.Now()
 	vres, verr := verify.Run(verify.Config{
 		ProjectPath: path,
@@ -147,6 +159,7 @@ func runPreflight(cmd *cobra.Command, args []string) error {
 		Vars:        parseVars(preflightVarsRaw),
 		DeviceModel: preflightDeviceModel,
 		OSVersion:   preflightOSVersion,
+		Artifact:    preflightArtifact,
 	})
 	if verr != nil {
 		return fmt.Errorf("runtime validation failed: %w", verr)

--- a/internal/cli/verify.go
+++ b/internal/cli/verify.go
@@ -16,7 +16,7 @@ import (
 var (
 	verifyBuildName   string
 	verifyFlows       []string
-	verifyVars        map[string]string
+	verifyVarsRaw     []string
 	verifyDeviceModel string
 	verifyOSVersion   string
 	verifyPlatform    string
@@ -57,7 +57,7 @@ Usage:
 func init() {
 	verifyCmd.Flags().StringVar(&verifyBuildName, "build-name", "", "Revyl registered build/app name (required to run; maps to YAML build.name)")
 	verifyCmd.Flags().StringSliceVar(&verifyFlows, "flows", nil, "limit to specific flows: account-deletion, restore-purchases, sign-in-apple")
-	verifyCmd.Flags().StringToStringVar(&verifyVars, "var", nil, "test variable, e.g. --var email=qa@acme.com (repeatable)")
+	verifyCmd.Flags().StringArrayVar(&verifyVarsRaw, "var", nil, "test variable, e.g. --var email=qa@acme.com (repeatable)")
 	verifyCmd.Flags().StringVar(&verifyDeviceModel, "device-model", "", "target device model, e.g. \"iPhone 16\"")
 	verifyCmd.Flags().StringVar(&verifyOSVersion, "os-version", "", "target OS version, e.g. \"iOS 26.2\"")
 	verifyCmd.Flags().StringVar(&verifyPlatform, "platform", "ios", "platform: ios or android")
@@ -99,7 +99,7 @@ func runVerify(cmd *cobra.Command, args []string) error {
 		BuildName:   verifyBuildName,
 		Platform:    verifyPlatform,
 		Flows:       verifyFlows,
-		Vars:        verifyVars,
+		Vars:        parseVars(verifyVarsRaw),
 		DeviceModel: verifyDeviceModel,
 		OSVersion:   verifyOSVersion,
 		Build:       verifyBuild,
@@ -126,6 +126,22 @@ func runVerify(cmd *cobra.Command, args []string) error {
 	}
 	writeVerifyTerminal(out, result)
 	return nil
+}
+
+// parseVars turns repeated --var key=value flags into a map. We split on the
+// first '=' ourselves rather than using pflag's StringToString, whose CSV parse
+// mangles values containing commas or multiple '=' (e.g. base64/JWT padding).
+func parseVars(raw []string) map[string]string {
+	if len(raw) == 0 {
+		return nil
+	}
+	m := make(map[string]string, len(raw))
+	for _, kv := range raw {
+		if i := strings.IndexByte(kv, '='); i > 0 {
+			m[kv[:i]] = kv[i+1:]
+		}
+	}
+	return m
 }
 
 func writeVerifyTerminal(w *os.File, r *verify.Result) {
@@ -328,6 +344,7 @@ func verifyJSONObject(r *verify.Result) interface{} {
 		Claims      interface{}         `json:"claims"`
 		Flows       []verify.FlowResult `json:"flows"`
 		Summary     verify.Summary      `json:"summary"`
+		Onboarding  *verify.Onboarding  `json:"onboarding,omitempty"`
 		DryRun      bool                `json:"dry_run"`
 		Elapsed     string              `json:"elapsed"`
 	}{
@@ -336,6 +353,7 @@ func verifyJSONObject(r *verify.Result) interface{} {
 		Claims:      r.Claims,
 		Flows:       r.Flows,
 		Summary:     r.Summary,
+		Onboarding:  r.Onboarding,
 		DryRun:      r.DryRun,
 		Elapsed:     r.Elapsed.Round(time.Millisecond).String(),
 	}

--- a/internal/cli/verify.go
+++ b/internal/cli/verify.go
@@ -91,15 +91,19 @@ func runVerify(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	purple.Println("\n  greenlight verify — does the flow actually work, on a cloud device?")
-	fmt.Printf("  Project: %s\n", path)
-	if verifyBuildName != "" {
-		fmt.Printf("  Build:   %s\n", verifyBuildName)
+	isJSON := strings.ToLower(verifyFormat) == "json"
+	// Keep stdout valid JSON when --format json: no human banner.
+	if !isJSON {
+		purple.Println("\n  greenlight verify — does the flow actually work, on a cloud device?")
+		fmt.Printf("  Project: %s\n", path)
+		if verifyBuildName != "" {
+			fmt.Printf("  Build:   %s\n", verifyBuildName)
+		}
+		if verifyDryRun {
+			dim.Println("  Mode:    dry-run (no device)")
+		}
+		fmt.Println()
 	}
-	if verifyDryRun {
-		dim.Println("  Mode:    dry-run (no device)")
-	}
-	fmt.Println()
 
 	start := time.Now()
 	result, err := verify.Run(verify.Config{
@@ -129,7 +133,7 @@ func runVerify(cmd *cobra.Command, args []string) error {
 		defer out.Close()
 	}
 
-	if strings.ToLower(verifyFormat) == "json" {
+	if isJSON {
 		return writeVerifyJSON(out, result)
 	}
 	writeVerifyTerminal(out, result)

--- a/internal/cli/verify.go
+++ b/internal/cli/verify.go
@@ -21,7 +21,9 @@ var (
 	verifyOSVersion   string
 	verifyPlatform    string
 	verifyBuild       bool
+	verifyArtifact    string
 	verifyDryRun      bool
+	verifyOpen        bool
 	verifyFormat      string
 	verifyOutput      string
 	verifyRevylBin    string
@@ -62,7 +64,9 @@ func init() {
 	verifyCmd.Flags().StringVar(&verifyOSVersion, "os-version", "", "target OS version, e.g. \"iOS 26.2\"")
 	verifyCmd.Flags().StringVar(&verifyPlatform, "platform", "ios", "platform: ios or android")
 	verifyCmd.Flags().BoolVar(&verifyBuild, "build", false, "build and upload via revyl before running")
+	verifyCmd.Flags().StringVar(&verifyArtifact, "artifact", "", "upload a prebuilt .app (iOS sim) or .apk (Android) to Revyl before running")
 	verifyCmd.Flags().BoolVar(&verifyDryRun, "dry-run", false, "generate the tests but do not execute on a device")
+	verifyCmd.Flags().BoolVar(&verifyOpen, "open", false, "auto-open the live Revyl session in your browser while it runs")
 	verifyCmd.Flags().StringVar(&verifyFormat, "format", "terminal", "output format: terminal, json")
 	verifyCmd.Flags().StringVar(&verifyOutput, "output", "", "write report to file (stdout if omitted)")
 	verifyCmd.Flags().StringVar(&verifyRevylBin, "revyl", "", "path to the revyl binary (default: auto-detect)")
@@ -90,6 +94,17 @@ func runVerify(cmd *cobra.Command, args []string) error {
 	if err := validateFlows(verifyFlows); err != nil {
 		return err
 	}
+	if verifyArtifact != "" {
+		if verifyBuild {
+			return fmt.Errorf("--artifact and --build are mutually exclusive: --artifact uploads a prebuilt binary; --build compiles from .revyl/config.yaml")
+		}
+		if verifyBuildName == "" {
+			return fmt.Errorf("--artifact requires --build-name (to name or match the Revyl app for the uploaded build)")
+		}
+		if err := verify.ValidateArtifact(verifyArtifact, platform); err != nil {
+			return err
+		}
+	}
 
 	isJSON := strings.ToLower(verifyFormat) == "json"
 	// Keep stdout valid JSON when --format json: no human banner.
@@ -99,8 +114,14 @@ func runVerify(cmd *cobra.Command, args []string) error {
 		if verifyBuildName != "" {
 			fmt.Printf("  Build:   %s\n", verifyBuildName)
 		}
+		if verifyArtifact != "" {
+			fmt.Printf("  Upload:  %s\n", verifyArtifact)
+		}
 		if verifyDryRun {
 			dim.Println("  Mode:    dry-run (no device)")
+			if verifyArtifact != "" {
+				dim.Println("  Note:    --artifact upload is skipped in dry-run")
+			}
 		}
 		fmt.Println()
 	}
@@ -115,9 +136,11 @@ func runVerify(cmd *cobra.Command, args []string) error {
 		DeviceModel: verifyDeviceModel,
 		OSVersion:   verifyOSVersion,
 		Build:       verifyBuild,
+		Artifact:    verifyArtifact,
 		Timeout:     time.Duration(verifyTimeout) * time.Second,
 		DryRun:      verifyDryRun,
 		RevylBin:    verifyRevylBin,
+		Open:        verifyOpen,
 	})
 	if err != nil {
 		return fmt.Errorf("verify failed: %w", err)
@@ -181,6 +204,15 @@ func writeVerifyTerminal(w *os.File, r *verify.Result) {
 	yellow := color.New(color.FgYellow)
 	greenC := color.New(color.FgGreen)
 	bold := color.New(color.Bold)
+
+	if r.Upload != nil {
+		switch r.Upload.Status {
+		case "uploaded":
+			greenC.Fprintf(w, "  ✓ Uploaded local build to Revyl: %s\n\n", r.Upload.Artifact)
+		case "failed":
+			red.Fprintf(w, "  ✗ Local build upload failed: %s\n\n", r.Upload.Detail)
+		}
+	}
 
 	var claimed []string
 	if r.Claims.AccountCreation {
@@ -371,14 +403,15 @@ func printVerifyFooter(w *os.File, r *verify.Result) {
 
 func verifyJSONObject(r *verify.Result) interface{} {
 	return struct {
-		ProjectPath string              `json:"project_path"`
-		BuildName   string              `json:"build_name,omitempty"`
-		Claims      interface{}         `json:"claims"`
-		Flows       []verify.FlowResult `json:"flows"`
-		Summary     verify.Summary      `json:"summary"`
-		Onboarding  *verify.Onboarding  `json:"onboarding,omitempty"`
-		DryRun      bool                `json:"dry_run"`
-		Elapsed     string              `json:"elapsed"`
+		ProjectPath string               `json:"project_path"`
+		BuildName   string               `json:"build_name,omitempty"`
+		Claims      interface{}          `json:"claims"`
+		Flows       []verify.FlowResult  `json:"flows"`
+		Summary     verify.Summary       `json:"summary"`
+		Onboarding  *verify.Onboarding   `json:"onboarding,omitempty"`
+		Upload      *verify.UploadResult `json:"upload,omitempty"`
+		DryRun      bool                 `json:"dry_run"`
+		Elapsed     string               `json:"elapsed"`
 	}{
 		ProjectPath: r.ProjectPath,
 		BuildName:   r.BuildName,
@@ -386,6 +419,7 @@ func verifyJSONObject(r *verify.Result) interface{} {
 		Flows:       r.Flows,
 		Summary:     r.Summary,
 		Onboarding:  r.Onboarding,
+		Upload:      r.Upload,
 		DryRun:      r.DryRun,
 		Elapsed:     r.Elapsed.Round(time.Millisecond).String(),
 	}

--- a/internal/cli/verify.go
+++ b/internal/cli/verify.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/RevylAI/greenlight/internal/revyl"
 	"github.com/RevylAI/greenlight/internal/verify"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -177,6 +178,11 @@ func writeVerifyTerminal(w *os.File, r *verify.Result) {
 			bold.Fprintf(w, "§%s %s\n", f.Guideline, f.Title)
 			fmt.Fprintf(w, "             could not run: %s\n", f.Detail)
 			fmt.Fprintln(w)
+		case verify.StatusPending:
+			yellow.Fprint(w, "  [pending]  ")
+			bold.Fprintf(w, "§%s %s\n", f.Guideline, f.Title)
+			dim.Fprintln(w, "             claimed in your code — validate it on a real device with Revyl")
+			fmt.Fprintln(w)
 		case verify.StatusSkipped:
 			dim.Fprintf(w, "  [skipped]  §%s %s — %s\n", f.Guideline, f.Title, f.Detail)
 		}
@@ -196,7 +202,61 @@ func writeVerifyTerminal(w *os.File, r *verify.Result) {
 		}
 	}
 
+	if r.Onboarding != nil {
+		printSignupCTA(w, r)
+		return
+	}
 	printVerifyFooter(w, r)
+}
+
+// printSignupCTA is the greenlight -> Revyl activation funnel: when a user
+// reaches the runtime tier without a Revyl account, show them exactly what
+// they'd unlock and how to sign up — instead of a raw auth error.
+func printSignupCTA(w *os.File, r *verify.Result) {
+	bold := color.New(color.Bold)
+	greenC := color.New(color.FgGreen)
+
+	dim.Fprintln(w, "  ─────────────────────────────────────────────")
+	fmt.Fprintln(w)
+
+	n := r.Summary.Pending
+	bold.Fprintf(w, "  %d flow(s) Apple will test that static analysis can't confirm.\n", n)
+	fmt.Fprint(w, "  Validate them on real devices with ")
+	purple.Fprint(w, "Revyl")
+	fmt.Fprintln(w, " — free to start.")
+	fmt.Fprintln(w)
+
+	switch r.Onboarding.Reason {
+	case verify.OnboardNotAuthenticated:
+		fmt.Fprintln(w, "  You have the Revyl CLI — you're one step away:")
+		fmt.Fprintln(w)
+		fmt.Fprint(w, "    Sign up free   ")
+		color.New(color.Underline).Fprintln(w, revyl.SignupURL)
+		fmt.Fprint(w, "    Then run       ")
+		greenC.Fprintln(w, revyl.LoginCmd)
+		dim.Fprintln(w, "    (already have an account? just run that)")
+	default: // OnboardCLIMissing
+		fmt.Fprintln(w, "  Three steps to your first runtime check:")
+		fmt.Fprintln(w)
+		fmt.Fprint(w, "    1. Sign up free    ")
+		color.New(color.Underline).Fprintln(w, revyl.SignupURL)
+		fmt.Fprint(w, "    2. Install the CLI ")
+		greenC.Fprintln(w, revyl.InstallCmd)
+		fmt.Fprint(w, "    3. Authenticate    ")
+		greenC.Fprintln(w, revyl.LoginCmd)
+	}
+
+	fmt.Fprintln(w)
+	fmt.Fprint(w, "  Then re-run:  ")
+	greenC.Fprintln(w, "greenlight verify . --build-name \"<your Revyl build>\"")
+
+	fmt.Fprintln(w)
+	dim.Fprintln(w, "  ─────────────────────────────────────────────")
+	fmt.Fprint(w, "  Powered by ")
+	purple.Fprint(w, "Revyl")
+	fmt.Fprintln(w, " — the mobile reliability platform")
+	dim.Fprintln(w, "  Static catches rejections. Revyl catches broken flows.")
+	fmt.Fprintln(w)
 }
 
 func printVerifyFooter(w *os.File, r *verify.Result) {

--- a/internal/cli/verify.go
+++ b/internal/cli/verify.go
@@ -1,0 +1,282 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/RevylAI/greenlight/internal/verify"
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+)
+
+var (
+	verifyBuildName   string
+	verifyFlows       []string
+	verifyVars        map[string]string
+	verifyDeviceModel string
+	verifyOSVersion   string
+	verifyPlatform    string
+	verifyBuild       bool
+	verifyDryRun      bool
+	verifyFormat      string
+	verifyOutput      string
+	verifyRevylBin    string
+	verifyTimeout     int
+)
+
+var verifyCmd = &cobra.Command{
+	Use:   "verify [path]",
+	Short: "Validate flow-dependent guidelines on a real device via Revyl",
+	Long: `Runtime tier. Static checks confirm a flow EXISTS in source; verify confirms
+it WORKS on a real device by handing flow-dependent guidelines to the Revyl CLI.
+
+This catches what static analysis structurally cannot: a 'Delete Account' button
+wired to nothing passes codescan — the string 'deleteAccount' is present, so §5.1.1
+is suppressed — but it dead-ends at runtime, and Apple rejects it. verify runs the
+flow on a device and catches it.
+
+Flows verified: account-deletion (§5.1.1), restore-purchases (§3.1.1),
+sign-in-apple (§4.8). Only flows your app actually claims are run.
+
+Unlike every other greenlight command this is NOT offline: it needs the revyl CLI,
+a Revyl account (revyl auth login), and a registered build. Run preflight first;
+run verify before you submit.
+
+Usage:
+  greenlight verify . --dry-run                                   # show the tests it would run, no device
+  greenlight verify . --build-name "My App" --var email=qa@acme.com --var password=secret
+  greenlight verify . --build-name "My App" --flows account-deletion --os-version "iOS 26.2"`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runVerify,
+}
+
+func init() {
+	verifyCmd.Flags().StringVar(&verifyBuildName, "build-name", "", "Revyl registered build/app name (required to run; maps to YAML build.name)")
+	verifyCmd.Flags().StringSliceVar(&verifyFlows, "flows", nil, "limit to specific flows: account-deletion, restore-purchases, sign-in-apple")
+	verifyCmd.Flags().StringToStringVar(&verifyVars, "var", nil, "test variable, e.g. --var email=qa@acme.com (repeatable)")
+	verifyCmd.Flags().StringVar(&verifyDeviceModel, "device-model", "", "target device model, e.g. \"iPhone 16\"")
+	verifyCmd.Flags().StringVar(&verifyOSVersion, "os-version", "", "target OS version, e.g. \"iOS 26.2\"")
+	verifyCmd.Flags().StringVar(&verifyPlatform, "platform", "ios", "platform: ios or android")
+	verifyCmd.Flags().BoolVar(&verifyBuild, "build", false, "build and upload via revyl before running")
+	verifyCmd.Flags().BoolVar(&verifyDryRun, "dry-run", false, "generate the tests but do not execute on a device")
+	verifyCmd.Flags().StringVar(&verifyFormat, "format", "terminal", "output format: terminal, json")
+	verifyCmd.Flags().StringVar(&verifyOutput, "output", "", "write report to file (stdout if omitted)")
+	verifyCmd.Flags().StringVar(&verifyRevylBin, "revyl", "", "path to the revyl binary (default: auto-detect)")
+	verifyCmd.Flags().IntVar(&verifyTimeout, "timeout", 0, "per-flow timeout in seconds (0 = revyl default)")
+	rootCmd.AddCommand(verifyCmd)
+}
+
+func runVerify(cmd *cobra.Command, args []string) error {
+	path := "."
+	if len(args) > 0 {
+		path = args[0]
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("cannot access path: %w", err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("path must be a directory: %s", path)
+	}
+
+	purple.Println("\n  greenlight verify — does the flow actually work, on a real device?")
+	fmt.Printf("  Project: %s\n", path)
+	if verifyBuildName != "" {
+		fmt.Printf("  Build:   %s\n", verifyBuildName)
+	}
+	if verifyDryRun {
+		dim.Println("  Mode:    dry-run (no device)")
+	}
+	fmt.Println()
+
+	start := time.Now()
+	result, err := verify.Run(verify.Config{
+		ProjectPath: path,
+		BuildName:   verifyBuildName,
+		Platform:    verifyPlatform,
+		Flows:       verifyFlows,
+		Vars:        verifyVars,
+		DeviceModel: verifyDeviceModel,
+		OSVersion:   verifyOSVersion,
+		Build:       verifyBuild,
+		Timeout:     time.Duration(verifyTimeout) * time.Second,
+		DryRun:      verifyDryRun,
+		RevylBin:    verifyRevylBin,
+	})
+	if err != nil {
+		return fmt.Errorf("verify failed: %w", err)
+	}
+	result.Elapsed = time.Since(start)
+
+	out := os.Stdout
+	if verifyOutput != "" {
+		out, err = os.Create(verifyOutput)
+		if err != nil {
+			return fmt.Errorf("failed to create output file: %w", err)
+		}
+		defer out.Close()
+	}
+
+	if strings.ToLower(verifyFormat) == "json" {
+		return writeVerifyJSON(out, result)
+	}
+	writeVerifyTerminal(out, result)
+	return nil
+}
+
+func writeVerifyTerminal(w *os.File, r *verify.Result) {
+	red := color.New(color.FgRed, color.Bold)
+	yellow := color.New(color.FgYellow)
+	greenC := color.New(color.FgGreen)
+	bold := color.New(color.Bold)
+
+	var claimed []string
+	if r.Claims.AccountCreation {
+		claimed = append(claimed, "account creation")
+	}
+	if r.Claims.IAP {
+		claimed = append(claimed, "in-app purchases")
+	}
+	if r.Claims.SocialLogin {
+		claimed = append(claimed, "social login")
+	}
+	if len(claimed) > 0 {
+		fmt.Fprintf(w, "  Flow-dependent features detected: %s\n\n", strings.Join(claimed, ", "))
+	} else {
+		dim.Fprintln(w, "  No flow-dependent features detected in source.")
+		fmt.Fprintln(w)
+	}
+
+	for _, f := range r.Flows {
+		switch f.Status {
+		case verify.StatusFailed:
+			red.Fprint(w, "  [FAILED]   ")
+			bold.Fprintf(w, "§%s %s\n", f.Guideline, f.Title)
+			if f.FailedStep != "" {
+				dim.Fprintf(w, "             failed at: %s\n", f.FailedStep)
+			}
+			fmt.Fprintf(w, "             %s\n", f.Detail)
+			if f.ReportURL != "" {
+				fmt.Fprint(w, "             report: ")
+				color.New(color.Underline).Fprintln(w, f.ReportURL)
+			}
+			fmt.Fprintln(w)
+		case verify.StatusVerified:
+			greenC.Fprint(w, "  [VERIFIED] ")
+			bold.Fprintf(w, "§%s %s\n", f.Guideline, f.Title)
+			dim.Fprintln(w, "             ran on-device and behaved correctly")
+			fmt.Fprintln(w)
+		case verify.StatusError:
+			yellow.Fprint(w, "  [SETUP]    ")
+			bold.Fprintf(w, "§%s %s\n", f.Guideline, f.Title)
+			fmt.Fprintf(w, "             could not run: %s\n", f.Detail)
+			fmt.Fprintln(w)
+		case verify.StatusSkipped:
+			dim.Fprintf(w, "  [skipped]  §%s %s — %s\n", f.Guideline, f.Title, f.Detail)
+		}
+	}
+
+	if r.DryRun {
+		fmt.Fprintln(w)
+		for _, f := range r.Flows {
+			if f.YAML == "" {
+				continue
+			}
+			dim.Fprintf(w, "  ── generated Revyl test: %s ──\n", f.ID)
+			for _, line := range strings.Split(strings.TrimRight(f.YAML, "\n"), "\n") {
+				fmt.Fprintf(w, "  %s\n", line)
+			}
+			fmt.Fprintln(w)
+		}
+	}
+
+	printVerifyFooter(w, r)
+}
+
+func printVerifyFooter(w *os.File, r *verify.Result) {
+	red := color.New(color.FgRed, color.Bold)
+	yellow := color.New(color.FgYellow)
+	green := color.New(color.FgGreen, color.Bold)
+	s := r.Summary
+
+	dim.Fprintln(w, "  ─────────────────────────────────────────────")
+	fmt.Fprintln(w)
+
+	switch {
+	case r.DryRun:
+		n := 0
+		for _, f := range r.Flows {
+			if f.YAML != "" {
+				n++
+			}
+		}
+		dim.Fprintf(w, "  dry-run — %d flow(s) would be verified on-device\n", n)
+	case s.Failed > 0:
+		red.Fprint(w, "  NOT READY")
+		fmt.Fprintf(w, " — %d flow(s) passed static analysis but FAILED on-device\n", s.Failed)
+	case s.Errored > 0 && s.Verified == 0:
+		yellow.Fprint(w, "  COULD NOT VERIFY")
+		fmt.Fprintf(w, " — %d flow(s) could not run (see setup notes above)\n", s.Errored)
+	case s.Verified > 0:
+		green.Fprint(w, "  VERIFIED")
+		fmt.Fprintf(w, " — %d flow(s) confirmed working on a real device", s.Verified)
+		if s.Errored > 0 {
+			fmt.Fprintf(w, ", %d could not run", s.Errored)
+		}
+		fmt.Fprintln(w)
+	default:
+		dim.Fprintln(w, "  nothing to verify")
+	}
+
+	if s.Total > 0 {
+		fmt.Fprintf(w, "  %d flow(s): ", s.Total)
+		if s.Failed > 0 {
+			red.Fprintf(w, "%d failed  ", s.Failed)
+		}
+		if s.Verified > 0 {
+			color.New(color.FgGreen).Fprintf(w, "%d verified  ", s.Verified)
+		}
+		if s.Errored > 0 {
+			yellow.Fprintf(w, "%d setup  ", s.Errored)
+		}
+		fmt.Fprintln(w)
+	}
+
+	dim.Fprintf(w, "  completed in %s\n", r.Elapsed.Round(time.Millisecond))
+
+	fmt.Fprintln(w)
+	dim.Fprintln(w, "  ─────────────────────────────────────────────")
+	fmt.Fprint(w, "  Powered by ")
+	purple.Fprint(w, "Revyl")
+	fmt.Fprintln(w, " — the mobile reliability platform")
+	dim.Fprintln(w, "  Static catches rejections. Revyl catches broken flows.")
+	fmt.Fprint(w, "  ")
+	color.New(color.Underline).Fprintln(w, "https://revyl.com")
+	fmt.Fprintln(w)
+}
+
+func writeVerifyJSON(w *os.File, r *verify.Result) error {
+	output := struct {
+		ProjectPath string              `json:"project_path"`
+		BuildName   string              `json:"build_name,omitempty"`
+		Claims      interface{}         `json:"claims"`
+		Flows       []verify.FlowResult `json:"flows"`
+		Summary     verify.Summary      `json:"summary"`
+		DryRun      bool                `json:"dry_run"`
+		Elapsed     string              `json:"elapsed"`
+	}{
+		ProjectPath: r.ProjectPath,
+		BuildName:   r.BuildName,
+		Claims:      r.Claims,
+		Flows:       r.Flows,
+		Summary:     r.Summary,
+		DryRun:      r.DryRun,
+		Elapsed:     r.Elapsed.Round(time.Millisecond).String(),
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(output)
+}

--- a/internal/cli/verify.go
+++ b/internal/cli/verify.go
@@ -30,9 +30,9 @@ var (
 
 var verifyCmd = &cobra.Command{
 	Use:   "verify [path]",
-	Short: "Validate flow-dependent guidelines on a real device via Revyl",
+	Short: "Validate flow-dependent guidelines on a cloud device via Revyl",
 	Long: `Runtime tier. Static checks confirm a flow EXISTS in source; verify confirms
-it WORKS on a real device by handing flow-dependent guidelines to the Revyl CLI.
+it WORKS on a cloud device by handing flow-dependent guidelines to the Revyl CLI.
 
 This catches what static analysis structurally cannot: a 'Delete Account' button
 wired to nothing passes codescan — the string 'deleteAccount' is present, so §5.1.1
@@ -83,7 +83,7 @@ func runVerify(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("path must be a directory: %s", path)
 	}
 
-	purple.Println("\n  greenlight verify — does the flow actually work, on a real device?")
+	purple.Println("\n  greenlight verify — does the flow actually work, on a cloud device?")
 	fmt.Printf("  Project: %s\n", path)
 	if verifyBuildName != "" {
 		fmt.Printf("  Build:   %s\n", verifyBuildName)
@@ -181,7 +181,7 @@ func writeVerifyTerminal(w *os.File, r *verify.Result) {
 		case verify.StatusPending:
 			yellow.Fprint(w, "  [pending]  ")
 			bold.Fprintf(w, "§%s %s\n", f.Guideline, f.Title)
-			dim.Fprintln(w, "             claimed in your code — validate it on a real device with Revyl")
+			dim.Fprintln(w, "             claimed in your code — validate it on a cloud device with Revyl")
 			fmt.Fprintln(w)
 		case verify.StatusSkipped:
 			dim.Fprintf(w, "  [skipped]  §%s %s — %s\n", f.Guideline, f.Title, f.Detail)
@@ -221,7 +221,7 @@ func printSignupCTA(w *os.File, r *verify.Result) {
 
 	n := r.Summary.Pending
 	bold.Fprintf(w, "  %d flow(s) Apple will test that static analysis can't confirm.\n", n)
-	fmt.Fprint(w, "  Validate them on real devices with ")
+	fmt.Fprint(w, "  Validate them on cloud devices with ")
 	purple.Fprint(w, "Revyl")
 	fmt.Fprintln(w, " — free to start.")
 	fmt.Fprintln(w)
@@ -285,7 +285,7 @@ func printVerifyFooter(w *os.File, r *verify.Result) {
 		fmt.Fprintf(w, " — %d flow(s) could not run (see setup notes above)\n", s.Errored)
 	case s.Verified > 0:
 		green.Fprint(w, "  VERIFIED")
-		fmt.Fprintf(w, " — %d flow(s) confirmed working on a real device", s.Verified)
+		fmt.Fprintf(w, " — %d flow(s) confirmed working on a cloud device", s.Verified)
 		if s.Errored > 0 {
 			fmt.Fprintf(w, ", %d could not run", s.Errored)
 		}

--- a/internal/cli/verify.go
+++ b/internal/cli/verify.go
@@ -261,8 +261,8 @@ func printVerifyFooter(w *os.File, r *verify.Result) {
 	fmt.Fprintln(w)
 }
 
-func writeVerifyJSON(w *os.File, r *verify.Result) error {
-	output := struct {
+func verifyJSONObject(r *verify.Result) interface{} {
+	return struct {
 		ProjectPath string              `json:"project_path"`
 		BuildName   string              `json:"build_name,omitempty"`
 		Claims      interface{}         `json:"claims"`
@@ -279,7 +279,10 @@ func writeVerifyJSON(w *os.File, r *verify.Result) error {
 		DryRun:      r.DryRun,
 		Elapsed:     r.Elapsed.Round(time.Millisecond).String(),
 	}
+}
+
+func writeVerifyJSON(w *os.File, r *verify.Result) error {
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
-	return enc.Encode(output)
+	return enc.Encode(verifyJSONObject(r))
 }

--- a/internal/cli/verify.go
+++ b/internal/cli/verify.go
@@ -158,6 +158,9 @@ func writeVerifyTerminal(w *os.File, r *verify.Result) {
 			if f.FailedStep != "" {
 				dim.Fprintf(w, "             failed at: %s\n", f.FailedStep)
 			}
+			if f.FailedReason != "" {
+				dim.Fprintf(w, "             reason: %s\n", f.FailedReason)
+			}
 			fmt.Fprintf(w, "             %s\n", f.Detail)
 			if f.ReportURL != "" {
 				fmt.Fprint(w, "             report: ")

--- a/internal/cli/verify.go
+++ b/internal/cli/verify.go
@@ -83,6 +83,14 @@ func runVerify(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("path must be a directory: %s", path)
 	}
 
+	platform := strings.ToLower(strings.TrimSpace(verifyPlatform))
+	if platform != "ios" && platform != "android" {
+		return fmt.Errorf("invalid --platform %q (expected ios or android)", verifyPlatform)
+	}
+	if err := validateFlows(verifyFlows); err != nil {
+		return err
+	}
+
 	purple.Println("\n  greenlight verify — does the flow actually work, on a cloud device?")
 	fmt.Printf("  Project: %s\n", path)
 	if verifyBuildName != "" {
@@ -97,9 +105,9 @@ func runVerify(cmd *cobra.Command, args []string) error {
 	result, err := verify.Run(verify.Config{
 		ProjectPath: path,
 		BuildName:   verifyBuildName,
-		Platform:    verifyPlatform,
 		Flows:       verifyFlows,
 		Vars:        parseVars(verifyVarsRaw),
+		Platform:    platform,
 		DeviceModel: verifyDeviceModel,
 		OSVersion:   verifyOSVersion,
 		Build:       verifyBuild,
@@ -142,6 +150,26 @@ func parseVars(raw []string) map[string]string {
 		}
 	}
 	return m
+}
+
+// validateFlows rejects any --flows id that isn't a known flow, so a typo fails
+// loudly instead of silently selecting nothing.
+func validateFlows(ids []string) error {
+	if len(ids) == 0 {
+		return nil
+	}
+	known := make(map[string]bool)
+	var all []string
+	for _, f := range verify.AllFlows() {
+		known[f.ID] = true
+		all = append(all, f.ID)
+	}
+	for _, id := range ids {
+		if !known[strings.TrimSpace(id)] {
+			return fmt.Errorf("unknown flow %q (valid: %s)", id, strings.Join(all, ", "))
+		}
+	}
+	return nil
 }
 
 func writeVerifyTerminal(w *os.File, r *verify.Result) {

--- a/internal/cli/verify_test.go
+++ b/internal/cli/verify_test.go
@@ -1,0 +1,24 @@
+package cli
+
+import "testing"
+
+// parseVars must split on the first '=' so credential values containing commas
+// or '=' (base64/JWT padding) survive intact — unlike pflag's StringToString.
+func TestParseVars(t *testing.T) {
+	m := parseVars([]string{"email=a,b@acme.com", "password=p@ss==w0rd", "noeq", "=noval"})
+	if m["email"] != "a,b@acme.com" {
+		t.Errorf("email = %q, want a,b@acme.com", m["email"])
+	}
+	if m["password"] != "p@ss==w0rd" {
+		t.Errorf("password = %q, want p@ss==w0rd", m["password"])
+	}
+	if _, ok := m["noeq"]; ok {
+		t.Errorf("entry without '=' should be skipped")
+	}
+	if len(m) != 2 {
+		t.Errorf("expected 2 entries, got %d: %v", len(m), m)
+	}
+	if parseVars(nil) != nil {
+		t.Errorf("nil input should return nil map")
+	}
+}

--- a/internal/cli/verify_test.go
+++ b/internal/cli/verify_test.go
@@ -22,3 +22,15 @@ func TestParseVars(t *testing.T) {
 		t.Errorf("nil input should return nil map")
 	}
 }
+
+func TestValidateFlows(t *testing.T) {
+	if err := validateFlows(nil); err != nil {
+		t.Errorf("nil flows should be valid: %v", err)
+	}
+	if err := validateFlows([]string{"account-deletion", "sign-in-apple"}); err != nil {
+		t.Errorf("known flows should be valid: %v", err)
+	}
+	if err := validateFlows([]string{"account-deletion", "nope"}); err == nil {
+		t.Errorf("unknown flow should error")
+	}
+}

--- a/internal/codescan/claims.go
+++ b/internal/codescan/claims.go
@@ -1,0 +1,78 @@
+package codescan
+
+import (
+	"regexp"
+	"strings"
+)
+
+// Claims describes which flow-dependent features an app *claims* to implement,
+// based on the same feature-detection patterns used by the static rules — but
+// WITHOUT the anti-pattern suppression. A claim means "Apple will exercise this
+// flow during review," which is exactly where static analysis goes blind: it can
+// confirm a string like `deleteAccount` exists in source, never that the flow works.
+type Claims struct {
+	// Feature presence — the trigger patterns from the static rules.
+	AccountCreation bool `json:"account_creation"`
+	IAP             bool `json:"iap"`
+	SocialLogin     bool `json:"social_login"`
+
+	// Anti-pattern presence — the strings that cause the static scanner to
+	// SUPPRESS the corresponding warning. When a feature is claimed AND its
+	// anti-pattern code is present, static reports GREENLIT — and that is the
+	// precise false-negative runtime validation exists to catch.
+	HasDeleteAccountCode bool `json:"has_delete_account_code"`
+	HasRestoreCode       bool `json:"has_restore_code"`
+	HasSignInWithApple   bool `json:"has_sign_in_with_apple"`
+}
+
+// These mirror the patterns/antiPatterns in rules.go for the three flow-dependent
+// rules (account-no-delete, iap-no-restore, social-login-no-apple). Kept in sync
+// deliberately: the runtime tier re-checks exactly the flows static can only guess.
+var (
+	reAccountCreation = regexp.MustCompile(`(?i)(createAccount|signUp|register.*user|create.*account|auth\(\)\.createUser)`)
+	reIAP             = regexp.MustCompile(`(?i)(SKPaymentQueue|StoreKit|Product\.purchase|purchaseProduct|expo-in-app-purchases|react-native-iap|RevenueCat)`)
+	reSocialLogin     = regexp.MustCompile(`(?i)(google.*sign.*in|GIDSignIn|GoogleSignin|facebook.*login|FBSDKLoginManager|LoginManager\.logIn)`)
+
+	reDeleteAccount = regexp.MustCompile(`(?i)(deleteAccount|delete.*account|remove.*account|account.*delet)`)
+	reRestore       = regexp.MustCompile(`(?i)(restoreCompletedTransactions|restore.*purchase|restorePurchase|customerInfo|syncPurchases)`)
+	reSiwA          = regexp.MustCompile(`(?i)(ASAuthorizationAppleIDProvider|SignInWithApple|apple.*auth|appleAuth|expo-apple-authentication)`)
+)
+
+// DetectClaims walks the project — reusing the scanner's file collection and
+// language detection — and reports which flow-dependent features are present.
+func DetectClaims(root string) (Claims, error) {
+	s := &Scanner{root: root}
+	files, err := s.collectFiles()
+	if err != nil {
+		return Claims{}, err
+	}
+
+	var c Claims
+	for _, fc := range files {
+		switch fc.Language {
+		case "swift", "objc", "typescript", "javascript":
+		default:
+			continue // ignore plist/json config — claims live in source
+		}
+		content := strings.Join(fc.Lines, "\n")
+		if reAccountCreation.MatchString(content) {
+			c.AccountCreation = true
+		}
+		if reIAP.MatchString(content) {
+			c.IAP = true
+		}
+		if reSocialLogin.MatchString(content) {
+			c.SocialLogin = true
+		}
+		if reDeleteAccount.MatchString(content) {
+			c.HasDeleteAccountCode = true
+		}
+		if reRestore.MatchString(content) {
+			c.HasRestoreCode = true
+		}
+		if reSiwA.MatchString(content) {
+			c.HasSignInWithApple = true
+		}
+	}
+	return c, nil
+}

--- a/internal/codescan/claims.go
+++ b/internal/codescan/claims.go
@@ -33,7 +33,7 @@ var (
 	reIAP             = regexp.MustCompile(`(?i)(SKPaymentQueue|StoreKit|Product\.purchase|purchaseProduct|expo-in-app-purchases|react-native-iap|RevenueCat)`)
 	reSocialLogin     = regexp.MustCompile(`(?i)(google.*sign.*in|GIDSignIn|GoogleSignin|facebook.*login|FBSDKLoginManager|LoginManager\.logIn)`)
 
-	reDeleteAccount = regexp.MustCompile(`(?i)(deleteAccount|delete.*account|remove.*account|account.*delet)`)
+	reDeleteAccount = regexp.MustCompile(`(?i)(deleteAccount|delete.*account|remove.*account|account.*delet|close.*account|closeAccount|cancel.*account|delete.*my.*account|erase.*account)`)
 	reRestore       = regexp.MustCompile(`(?i)(restoreCompletedTransactions|restore.*purchase|restorePurchase|customerInfo|syncPurchases)`)
 	reSiwA          = regexp.MustCompile(`(?i)(ASAuthorizationAppleIDProvider|SignInWithApple|apple.*auth|appleAuth|expo-apple-authentication)`)
 )

--- a/internal/codescan/rules.go
+++ b/internal/codescan/rules.go
@@ -151,7 +151,7 @@ func AllRules() []Rule {
 				regexp.MustCompile(`(?i)(createAccount|signUp|register.*user|create.*account|auth\(\)\.createUser)`),
 			},
 			antiPatterns: []*regexp.Regexp{
-				regexp.MustCompile(`(?i)(deleteAccount|delete.*account|remove.*account|account.*delet|close.*account|closeAccount|account.*clos|cancel.*account|delete.*my.*(data|account)|erase.*account)`),
+				regexp.MustCompile(`(?i)(deleteAccount|delete.*account|remove.*account|account.*delet|close.*account|closeAccount|cancel.*account|delete.*my.*account|erase.*account)`),
 			},
 			antiPatternsGlobal: true,
 			firstMatchOnly:     true,
@@ -287,7 +287,7 @@ type PatternRule struct {
 	antiPatternsGlobal bool             // Check anti-patterns across all files, not just current
 	ignorePatterns     []*regexp.Regexp // Lines matching these are skipped
 	countThreshold     int              // Only report if count exceeds this
-	firstMatchOnly     bool             // Report at most one finding per file (project-level facts)
+	firstMatchOnly     bool             // Project-level fact: cap to one per file; scanner collapses to one per project
 }
 
 func (r *PatternRule) RuleID() string { return r.id }

--- a/internal/codescan/rules.go
+++ b/internal/codescan/rules.go
@@ -36,7 +36,7 @@ func AllRules() []Rule {
 			patterns: []*regexp.Regexp{
 				regexp.MustCompile(`(?i)(sk_live_|sk_test_|pk_live_|pk_test_)[a-zA-Z0-9]{20,}`),
 				regexp.MustCompile(`(?i)(api[_-]?key|api[_-]?secret|secret[_-]?key)\s*[:=]\s*["'][a-zA-Z0-9]{20,}["']`),
-				regexp.MustCompile(`(?i)AKIA[0-9A-Z]{16}`), // AWS access key
+				regexp.MustCompile(`(?i)AKIA[0-9A-Z]{16}`),    // AWS access key
 				regexp.MustCompile(`(?i)ghp_[a-zA-Z0-9]{36}`), // GitHub token
 			},
 		},
@@ -96,13 +96,14 @@ func AllRules() []Rule {
 			languages: []string{"swift", "objc", "typescript", "javascript"},
 			patterns: []*regexp.Regexp{
 				regexp.MustCompile(`(?i)(firebase.*analytics|google.*analytics|facebook.*sdk|fbsdk|adjust.*sdk|appsflyer|mixpanel)`),
-			regexp.MustCompile(`(?i)(import\s+Amplitude|AmplitudeSwift|amplitude\.init|Amplitude\.instance|amplitude-js|@amplitude/)`),
+				regexp.MustCompile(`(?i)(import\s+Amplitude|AmplitudeSwift|amplitude\.init|Amplitude\.instance|amplitude-js|@amplitude/)`),
 				regexp.MustCompile(`(?i)(import.*@segment/|analytics-react-native|SegmentAnalytics|createClient.*writeKey)`),
 			},
 			antiPatterns: []*regexp.Regexp{
 				regexp.MustCompile(`(?i)(ATTrackingManager|requestTrackingAuthorization|AppTrackingTransparency|expo-tracking-transparency)`),
 			},
 			antiPatternsGlobal: true,
+			firstMatchOnly:     true,
 		},
 		&PatternRule{
 			id:        "social-login-no-apple",
@@ -119,6 +120,7 @@ func AllRules() []Rule {
 				regexp.MustCompile(`(?i)(ASAuthorizationAppleIDProvider|SignInWithApple|apple.*auth|appleAuth|expo-apple-authentication)`),
 			},
 			antiPatternsGlobal: true,
+			firstMatchOnly:     true,
 		},
 		&PatternRule{
 			id:        "iap-no-restore",
@@ -135,6 +137,7 @@ func AllRules() []Rule {
 				regexp.MustCompile(`(?i)(restoreCompletedTransactions|restore.*purchase|restorePurchase|customerInfo|syncPurchases)`),
 			},
 			antiPatternsGlobal: true,
+			firstMatchOnly:     true,
 		},
 		&PatternRule{
 			id:        "account-no-delete",
@@ -148,9 +151,10 @@ func AllRules() []Rule {
 				regexp.MustCompile(`(?i)(createAccount|signUp|register.*user|create.*account|auth\(\)\.createUser)`),
 			},
 			antiPatterns: []*regexp.Regexp{
-				regexp.MustCompile(`(?i)(deleteAccount|delete.*account|remove.*account|account.*delet)`),
+				regexp.MustCompile(`(?i)(deleteAccount|delete.*account|remove.*account|account.*delet|close.*account|closeAccount|account.*clos|cancel.*account|delete.*my.*(data|account)|erase.*account)`),
 			},
 			antiPatternsGlobal: true,
+			firstMatchOnly:     true,
 		},
 
 		// MEDIUM - May cause issues
@@ -178,10 +182,10 @@ func AllRules() []Rule {
 			fix:       "Replace all placeholder text with final content.",
 			languages: []string{"swift", "objc", "typescript", "javascript"},
 			patterns: []*regexp.Regexp{
-				regexp.MustCompile(`(?i)"[^"]*\b(lorem ipsum|placeholder|coming soon|under construction|todo|tbd)\b[^"]*"`),
-				regexp.MustCompile(`(?i)'[^']*\b(lorem ipsum|placeholder|coming soon|under construction|todo|tbd)\b[^']*'`),
-				regexp.MustCompile("(?i)`[^`]*\\b(lorem ipsum|placeholder|coming soon|under construction|todo|tbd)\\b[^`]*`"),
-				regexp.MustCompile(`(?i)\b(lorem ipsum|placeholder|coming soon|under construction|todo|tbd)\b`), // bare text (JSX content)
+				regexp.MustCompile(`(?i)"[^"]*\b(lorem ipsum|coming soon|under construction|todo|tbd)\b[^"]*"`),
+				regexp.MustCompile(`(?i)'[^']*\b(lorem ipsum|coming soon|under construction|todo|tbd)\b[^']*'`),
+				regexp.MustCompile("(?i)`[^`]*\\b(lorem ipsum|coming soon|under construction|todo|tbd)\\b[^`]*`"),
+				regexp.MustCompile(`(?i)\b(lorem ipsum|coming soon|under construction|todo|tbd)\b`), // bare text (JSX content)
 			},
 			ignorePatterns: []*regexp.Regexp{
 				regexp.MustCompile(`(?i)(func\s+placeholder\s*\(|\.placeholder\s*[:=]|placeholder\s*[:=]\s*[A-Z]|placeholder\s*\(in\s*context)`), // Swift/WidgetKit protocol methods and property assignments
@@ -283,6 +287,7 @@ type PatternRule struct {
 	antiPatternsGlobal bool             // Check anti-patterns across all files, not just current
 	ignorePatterns     []*regexp.Regexp // Lines matching these are skipped
 	countThreshold     int              // Only report if count exceeds this
+	firstMatchOnly     bool             // Report at most one finding per file (project-level facts)
 }
 
 func (r *PatternRule) RuleID() string { return r.id }
@@ -354,6 +359,13 @@ func (r *PatternRule) Check(fc FileContext) []Finding {
 		return nil
 	}
 
+	// "Missing safeguard" rules describe a project-level fact (e.g. account
+	// creation exists but deletion doesn't) — one finding is enough, not one per
+	// matching line.
+	if r.firstMatchOnly && len(findings) > 1 {
+		findings = findings[:1]
+	}
+
 	return findings
 }
 
@@ -374,15 +386,15 @@ func (r *PlistKeyRule) Check(fc FileContext) []Finding {
 	var findings []Finding
 
 	requiredIfUsed := map[string]string{
-		"NSCameraUsageDescription":          "Camera",
-		"NSMicrophoneUsageDescription":      "Microphone",
-		"NSPhotoLibraryUsageDescription":    "Photo Library",
+		"NSCameraUsageDescription":            "Camera",
+		"NSMicrophoneUsageDescription":        "Microphone",
+		"NSPhotoLibraryUsageDescription":      "Photo Library",
 		"NSLocationWhenInUseUsageDescription": "Location (When In Use)",
-		"NSLocationAlwaysUsageDescription":  "Location (Always)",
-		"NSBluetoothAlwaysUsageDescription": "Bluetooth",
-		"NSMotionUsageDescription":          "Motion/Accelerometer",
-		"NSFaceIDUsageDescription":          "Face ID",
-		"NSUserTrackingUsageDescription":    "App Tracking",
+		"NSLocationAlwaysUsageDescription":    "Location (Always)",
+		"NSBluetoothAlwaysUsageDescription":   "Bluetooth",
+		"NSMotionUsageDescription":            "Motion/Accelerometer",
+		"NSFaceIDUsageDescription":            "Face ID",
+		"NSUserTrackingUsageDescription":      "App Tracking",
 	}
 
 	for key, name := range requiredIfUsed {

--- a/internal/codescan/rules_test.go
+++ b/internal/codescan/rules_test.go
@@ -17,9 +17,9 @@ func swiftCtx(lines ...string) FileContext {
 	return FileContext{Path: "X.swift", RelPath: "X.swift", Lines: lines, Language: "swift"}
 }
 
-// SwiftUI's `placeholder:` parameter and example hint text are not App
-// Completeness violations — the §2.1 rule must not flag them (it used to fire on
-// the bare word "placeholder", turning normal apps into dozens of warnings).
+// The §2.1 placeholder-content rule must not fire on SwiftUI's `placeholder:`
+// parameter or example hint text. It used to match the bare word "placeholder",
+// turning normal apps into dozens of warnings; re-adding it would fail this test.
 func TestPlaceholderRuleIgnoresSwiftUIPlaceholder(t *testing.T) {
 	r := ruleByID(t, "placeholder-content")
 
@@ -56,7 +56,9 @@ func TestAccountDeleteAntiPatterns(t *testing.T) {
 		}
 	}
 	notSuppress := []string{
-		`Button("Deactivate") {}`, // deactivate != delete
+		`Button("Deactivate") {}`,      // deactivate != delete
+		`let accountClosed = navPop()`, // incidental, not a deletion control
+		`Button("Delete my data") {}`,  // GDPR data deletion != account deletion
 		`let balance = 100`,
 	}
 	for _, line := range notSuppress {

--- a/internal/codescan/rules_test.go
+++ b/internal/codescan/rules_test.go
@@ -1,0 +1,81 @@
+package codescan
+
+import "testing"
+
+func ruleByID(t *testing.T, id string) *PatternRule {
+	t.Helper()
+	for _, r := range AllRules() {
+		if pr, ok := r.(*PatternRule); ok && pr.id == id {
+			return pr
+		}
+	}
+	t.Fatalf("rule %q not found", id)
+	return nil
+}
+
+func swiftCtx(lines ...string) FileContext {
+	return FileContext{Path: "X.swift", RelPath: "X.swift", Lines: lines, Language: "swift"}
+}
+
+// SwiftUI's `placeholder:` parameter and example hint text are not App
+// Completeness violations — the §2.1 rule must not flag them (it used to fire on
+// the bare word "placeholder", turning normal apps into dozens of warnings).
+func TestPlaceholderRuleIgnoresSwiftUIPlaceholder(t *testing.T) {
+	r := ruleByID(t, "placeholder-content")
+
+	clean := swiftCtx(
+		`VaultTextField(label: "Email", text: $email, placeholder: "you@example.com")`,
+		`SecureField(placeholder, text: $text)`,
+		`VaultTextField(label: "CVC", text: $cvc, placeholder: "123")`,
+	)
+	if got := r.Check(clean); len(got) != 0 {
+		t.Errorf("expected no findings for SwiftUI placeholders, got %d: %+v", len(got), got)
+	}
+
+	// Real placeholder content must still be caught.
+	dirty := swiftCtx(`Text("Lorem ipsum dolor sit amet")`)
+	if got := r.Check(dirty); len(got) == 0 {
+		t.Errorf("expected a finding for real placeholder content")
+	}
+}
+
+// §5.1.1 must recognize "Close account" / "cancel account" as deletion (Vault
+// labels it "Close account") — but NOT "deactivate", which Apple deems
+// insufficient.
+func TestAccountDeleteAntiPatterns(t *testing.T) {
+	r := ruleByID(t, "account-no-delete")
+	suppress := []string{
+		`Button("Close account") {}`,
+		`func closeAccount() {}`,
+		`onTap: deleteAccount`,
+		`"Cancel account"`,
+	}
+	for _, line := range suppress {
+		if !r.AntiPatternMatched(swiftCtx(line)) {
+			t.Errorf("expected %q to count as account deletion", line)
+		}
+	}
+	notSuppress := []string{
+		`Button("Deactivate") {}`, // deactivate != delete
+		`let balance = 100`,
+	}
+	for _, line := range notSuppress {
+		if r.AntiPatternMatched(swiftCtx(line)) {
+			t.Errorf("expected %q NOT to count as account deletion", line)
+		}
+	}
+}
+
+// "Missing safeguard" rules describe one project-level fact — they must report
+// once, not once per matching line.
+func TestFirstMatchOnly(t *testing.T) {
+	r := ruleByID(t, "account-no-delete")
+	ctx := swiftCtx(
+		`func createAccount() {}`,
+		`struct SignUpScreen {}`,
+		`button: createAccount`,
+	)
+	if got := r.Check(ctx); len(got) != 1 {
+		t.Errorf("expected exactly 1 finding (firstMatchOnly), got %d", len(got))
+	}
+}

--- a/internal/codescan/scanner.go
+++ b/internal/codescan/scanner.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 )
@@ -114,6 +115,17 @@ func dedupOnceRules(rules []Rule, findings []Finding) []Finding {
 	if len(once) == 0 {
 		return findings
 	}
+	// Findings are appended from goroutines, so their order is nondeterministic.
+	// Sort by file/line/title so the surviving finding per rule is stable.
+	sort.SliceStable(findings, func(i, j int) bool {
+		if findings[i].File != findings[j].File {
+			return findings[i].File < findings[j].File
+		}
+		if findings[i].Line != findings[j].Line {
+			return findings[i].Line < findings[j].Line
+		}
+		return findings[i].Title < findings[j].Title
+	})
 	seen := make(map[string]bool)
 	var out []Finding
 	for _, f := range findings {

--- a/internal/codescan/scanner.go
+++ b/internal/codescan/scanner.go
@@ -94,7 +94,38 @@ func (s *Scanner) Scan() ([]Finding, error) {
 	}
 
 	wg.Wait()
+
+	// Collapse "missing safeguard" findings (firstMatchOnly rules) to one each
+	// across the whole project, so the same project-level fact isn't reported
+	// once per file that happens to trigger it.
+	findings = dedupOnceRules(s.rules, findings)
 	return findings, nil
+}
+
+// dedupOnceRules keeps a single finding (by title) for each firstMatchOnly rule,
+// preserving order and leaving every other rule's findings untouched.
+func dedupOnceRules(rules []Rule, findings []Finding) []Finding {
+	once := make(map[string]bool)
+	for _, r := range rules {
+		if pr, ok := r.(*PatternRule); ok && pr.firstMatchOnly {
+			once[pr.title] = true
+		}
+	}
+	if len(once) == 0 {
+		return findings
+	}
+	seen := make(map[string]bool)
+	var out []Finding
+	for _, f := range findings {
+		if once[f.Title] {
+			if seen[f.Title] {
+				continue
+			}
+			seen[f.Title] = true
+		}
+		out = append(out, f)
+	}
+	return out
 }
 
 func (s *Scanner) collectFiles() ([]FileContext, error) {

--- a/internal/codescan/scanner.go
+++ b/internal/codescan/scanner.go
@@ -110,7 +110,7 @@ func dedupOnceRules(rules []Rule, findings []Finding) []Finding {
 	once := make(map[string]bool)
 	for _, r := range rules {
 		if pr, ok := r.(*PatternRule); ok && pr.firstMatchOnly {
-			once[pr.title] = true
+			once[pr.guideline+"\x00"+pr.title] = true
 		}
 	}
 	if len(once) == 0 {
@@ -130,11 +130,12 @@ func dedupOnceRules(rules []Rule, findings []Finding) []Finding {
 	seen := make(map[string]bool)
 	var out []Finding
 	for _, f := range findings {
-		if once[f.Title] {
-			if seen[f.Title] {
+		key := f.Guideline + "\x00" + f.Title
+		if once[key] {
+			if seen[key] {
 				continue
 			}
-			seen[f.Title] = true
+			seen[key] = true
 		}
 		out = append(out, f)
 	}

--- a/internal/codescan/scanner.go
+++ b/internal/codescan/scanner.go
@@ -103,8 +103,9 @@ func (s *Scanner) Scan() ([]Finding, error) {
 	return findings, nil
 }
 
-// dedupOnceRules keeps a single finding (by title) for each firstMatchOnly rule,
-// preserving order and leaving every other rule's findings untouched.
+// dedupOnceRules keeps a single finding (by title) for each firstMatchOnly rule.
+// It stably sorts all findings by file/line/title first so the surviving finding
+// is deterministic; other rules' findings are otherwise kept.
 func dedupOnceRules(rules []Rule, findings []Finding) []Finding {
 	once := make(map[string]bool)
 	for _, r := range rules {

--- a/internal/revyl/client.go
+++ b/internal/revyl/client.go
@@ -73,10 +73,51 @@ func (c *Client) Authenticated() bool {
 	return strings.Contains(l, "authenticated") || strings.Contains(l, "logged in")
 }
 
-// EnsureTest creates or updates a Revyl test from a YAML file. Idempotent via
-// --force; --no-open keeps it headless.
-func (c *Client) EnsureTest(yamlPath string) (string, error) {
-	out, err := c.run("test", "create", "--from-file", yamlPath, "--no-open", "--force")
+// AppID resolves a registered build/app name to its Revyl app id. Passing the id
+// to `revyl test create --app` is what associates the build for installation —
+// without it, `revyl test run` never installs/launches the app (zero steps).
+func (c *Client) AppID(name string) (string, error) {
+	out, err := c.run("app", "list", "--json")
+	if err != nil {
+		return "", fmt.Errorf("revyl app list failed: %w", err)
+	}
+	var resp struct {
+		Apps []struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		} `json:"apps"`
+	}
+	if js := extractJSON(out); js != "" {
+		if e := json.Unmarshal([]byte(js), &resp); e != nil {
+			return "", fmt.Errorf("could not parse app list: %w", e)
+		}
+	}
+	for _, a := range resp.Apps { // exact match first
+		if a.Name == name {
+			return a.ID, nil
+		}
+	}
+	for _, a := range resp.Apps { // then case-insensitive
+		if strings.EqualFold(a.Name, name) {
+			return a.ID, nil
+		}
+	}
+	return "", fmt.Errorf("no Revyl app named %q", name)
+}
+
+// EnsureTest creates a Revyl test from a YAML file, bound to appID. It deletes
+// any prior test of the same name first so the run is always freshly bound to
+// the right build (a stale --force from an unsynced dir conflicts). Runs in the
+// YAML's own dir so revyl's `.revyl/` scratch never pollutes the user's project.
+func (c *Client) EnsureTest(name, yamlPath, appID string) (string, error) {
+	dir := filepath.Dir(yamlPath)
+	_, _ = c.runIn(dir, "test", "delete", name, "--force") // ignore "not found"
+
+	args := []string{"test", "create", "--from-file", yamlPath, "--no-open"}
+	if appID != "" {
+		args = append(args, "--app", appID)
+	}
+	out, err := c.runIn(dir, args...)
 	if err != nil {
 		return out, fmt.Errorf("revyl test create failed: %w\n%s", err, strings.TrimSpace(out))
 	}
@@ -258,8 +299,15 @@ func cleanReason(s string) string {
 }
 
 func (c *Client) run(args ...string) (string, error) {
+	return c.runIn("", args...)
+}
+
+func (c *Client) runIn(dir string, args ...string) (string, error) {
 	cmd := exec.Command(c.Bin, args...)
 	cmd.Env = os.Environ()
+	if dir != "" {
+		cmd.Dir = dir
+	}
 	out, err := cmd.CombinedOutput()
 	return string(out), err
 }

--- a/internal/revyl/client.go
+++ b/internal/revyl/client.go
@@ -52,10 +52,10 @@ func (c *Client) Available() error {
 	if _, err := exec.LookPath(c.Bin); err == nil {
 		return nil
 	}
-	if _, err := os.Stat(c.Bin); err == nil {
+	if fi, err := os.Stat(c.Bin); err == nil && !fi.IsDir() && fi.Mode()&0o111 != 0 {
 		return nil
 	}
-	return fmt.Errorf("revyl CLI not found (looked for %q) — install it (https://docs.revyl.com) or pass --revyl <path>", c.Bin)
+	return fmt.Errorf("revyl CLI not found or not executable (looked for %q): install it (https://docs.revyl.com) or pass --revyl <path>", c.Bin)
 }
 
 // Authenticated reports whether the user has a usable Revyl session. Used to
@@ -87,10 +87,12 @@ func (c *Client) AppID(name string) (string, error) {
 			Name string `json:"name"`
 		} `json:"apps"`
 	}
-	if js := extractJSON(out); js != "" {
-		if e := json.Unmarshal([]byte(js), &resp); e != nil {
-			return "", fmt.Errorf("could not parse app list: %w", e)
-		}
+	js := extractJSON(out)
+	if js == "" {
+		return "", fmt.Errorf("could not parse `revyl app list --json`: no JSON in output")
+	}
+	if e := json.Unmarshal([]byte(js), &resp); e != nil {
+		return "", fmt.Errorf("could not parse app list: %w", e)
 	}
 	for _, a := range resp.Apps { // exact match first
 		if a.Name == name {
@@ -251,10 +253,12 @@ func (c *Client) Report(name string) (ReportResult, error) {
 func parseReport(out string) (ReportResult, error) {
 	var res ReportResult
 	var j reportJSON
-	if js := extractJSON(out); js != "" {
-		if e := json.Unmarshal([]byte(js), &j); e != nil {
-			return res, fmt.Errorf("could not parse report JSON: %w", e)
-		}
+	js := extractJSON(out)
+	if js == "" {
+		return res, fmt.Errorf("no JSON found in `revyl test report --json` output")
+	}
+	if e := json.Unmarshal([]byte(js), &j); e != nil {
+		return res, fmt.Errorf("could not parse report JSON: %w", e)
 	}
 
 	res.ReportURL = j.ReportURL

--- a/internal/revyl/client.go
+++ b/internal/revyl/client.go
@@ -6,6 +6,7 @@ package revyl
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -117,6 +118,17 @@ func (c *Client) RunTest(name string, opts RunOpts) (RunResult, error) {
 
 	out, runErr := c.run(args...)
 	res := RunResult{Raw: out}
+
+	// A non-exit error means revyl itself couldn't run (binary/IO problem) — a
+	// hard error. A non-zero EXIT is just a failed test; let the report decide
+	// whether that's a broken flow or a setup/launch failure. Never classify
+	// from stdout keywords — that's what the structured report is for.
+	if runErr != nil {
+		var ee *exec.ExitError
+		if !errors.As(runErr, &ee) {
+			return res, fmt.Errorf("could not execute revyl test run: %w\n%s", runErr, strings.TrimSpace(out))
+		}
+	}
 	exitOK := runErr == nil
 
 	var j runJSON
@@ -134,13 +146,6 @@ func (c *Client) RunTest(name string, opts RunOpts) (RunResult, error) {
 	if !res.Passed {
 		res.FailedStep = j.firstFailedStep()
 	}
-
-	// Distinguish "the flow failed" (a real finding) from "couldn't run the flow"
-	// (auth/build/device setup) — the latter must never read as a passed or
-	// failed verdict.
-	if runErr != nil && !decided && looksLikeSetupError(out) {
-		return res, fmt.Errorf("revyl test run could not execute: %w\n%s", runErr, strings.TrimSpace(out))
-	}
 	return res, nil
 }
 
@@ -155,12 +160,14 @@ func (c *Client) ReportShareURL(name string) string {
 }
 
 // ReportResult is the authoritative outcome of a test's latest execution,
-// extracted from `revyl test report --json`. session_status is Revyl's verdict;
-// the failing step's description and reason are the evidence a static scanner
-// can never produce.
+// extracted from `revyl test report --json`. The verdict is Revyl's; the failing
+// step's description and reason are the evidence a static scanner can't produce.
+// StepsRun matters for honesty: a "failed" run that executed zero steps is a
+// setup/launch failure, NOT a flow that broke.
 type ReportResult struct {
 	Decided      bool
 	Passed       bool
+	StepsRun     int
 	FailedStep   string
 	FailedReason string
 	ReportURL    string
@@ -171,6 +178,10 @@ type ReportResult struct {
 // reportJSON mirrors the real `revyl test report --json` schema.
 type reportJSON struct {
 	SessionStatus string `json:"session_status"`
+	Success       *bool  `json:"success"`
+	TotalSteps    int    `json:"total_steps"`
+	PassedSteps   int    `json:"passed_steps"`
+	FailedSteps   int    `json:"failed_steps"`
 	ReportURL     string `json:"report_url"`
 	DeviceModel   string `json:"device_model"`
 	OSVersion     string `json:"os_version"`
@@ -208,12 +219,20 @@ func parseReport(out string) (ReportResult, error) {
 	res.ReportURL = j.ReportURL
 	res.DeviceModel = j.DeviceModel
 	res.OSVersion = j.OSVersion
+	// StepsRun counts steps that actually executed (passed or failed). Zero means
+	// the flow never ran a step — a setup/launch failure, not a broken flow.
+	res.StepsRun = j.PassedSteps + j.FailedSteps
 
-	switch strings.ToLower(strings.TrimSpace(j.SessionStatus)) {
-	case "passed", "pass", "success", "succeeded", "completed", "complete", "green":
-		res.Passed, res.Decided = true, true
-	case "failed", "fail", "failure", "error", "errored", "red":
-		res.Passed, res.Decided = false, true
+	// Prefer the explicit success boolean; fall back to session_status text.
+	if j.Success != nil {
+		res.Passed, res.Decided = *j.Success, true
+	} else {
+		switch strings.ToLower(strings.TrimSpace(j.SessionStatus)) {
+		case "passed", "pass", "success", "succeeded", "completed", "complete", "green":
+			res.Passed, res.Decided = true, true
+		case "failed", "fail", "failure", "error", "errored", "red":
+			res.Passed, res.Decided = false, true
+		}
 	}
 
 	for _, s := range j.Steps {
@@ -318,18 +337,4 @@ func firstNonEmpty(vals ...string) string {
 		}
 	}
 	return ""
-}
-
-func looksLikeSetupError(s string) bool {
-	l := strings.ToLower(s)
-	for _, k := range []string{
-		"not authenticated", "unauthorized", "please log in", "auth login",
-		"no build", "build not found", "no device", "no runners", "not found",
-		"quota", "permission denied", "forbidden", "could not connect",
-	} {
-		if strings.Contains(l, k) {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/revyl/client.go
+++ b/internal/revyl/client.go
@@ -107,6 +107,51 @@ func (c *Client) AppID(name string) (string, error) {
 	return "", fmt.Errorf("no Revyl app named %q", name)
 }
 
+// CreateApp registers a new app (a named container for build versions) and
+// returns its id. This is an explicit, headless step: `build upload --name` on
+// an unconfigured project otherwise drops into an interactive app picker that
+// hangs when there's no TTY (we shell out without one).
+func (c *Client) CreateApp(name, platform string) (string, error) {
+	if platform == "" {
+		platform = "ios"
+	}
+	out, err := c.run("app", "create", "--name", name, "--platform", platform, "--json")
+	if err != nil {
+		return "", fmt.Errorf("revyl app create failed: %w\n%s", err, strings.TrimSpace(out))
+	}
+	js := extractJSON(out)
+	if js == "" {
+		return "", fmt.Errorf("could not parse `revyl app create --json`: no JSON in output")
+	}
+	var r struct {
+		ID    string `json:"id"`
+		AppID string `json:"app_id"`
+	}
+	if e := json.Unmarshal([]byte(js), &r); e != nil {
+		return "", fmt.Errorf("could not parse app create response: %w", e)
+	}
+	id := firstNonEmpty(r.ID, r.AppID)
+	if id == "" {
+		return "", fmt.Errorf("revyl app create returned no app id")
+	}
+	return id, nil
+}
+
+// UploadBuild uploads a PRE-BUILT artifact to an existing Revyl app (by id) and
+// marks it current, so the subsequent `test run` installs it. Revyl runs on
+// cloud simulators, so it ingests a simulator .app bundle (iOS) or an .apk
+// (Android) — never a signed device .ipa. `--file` skips any config-based build.
+func (c *Client) UploadBuild(artifact, appID string) (string, error) {
+	if appID == "" {
+		return "", fmt.Errorf("UploadBuild needs an app id")
+	}
+	out, err := c.run("build", "upload", "--file", artifact, "--app", appID, "--set-current")
+	if err != nil {
+		return out, fmt.Errorf("revyl build upload failed: %w\n%s", err, strings.TrimSpace(out))
+	}
+	return out, nil
+}
+
 // EnsureTest creates a Revyl test from a YAML file, bound to appID. It deletes
 // any prior test of the same name first so the run is always freshly bound to
 // the right build (a stale --force from an unsynced dir conflicts). Runs in the
@@ -190,6 +235,29 @@ func (c *Client) RunTest(name string, opts RunOpts) (RunResult, error) {
 		res.FailedStep = j.firstFailedStep()
 	}
 	return res, nil
+}
+
+// SessionURL returns the live session view link for a test's current execution,
+// best-effort (empty until the session registers). Format:
+//
+//	https://app.revyl.ai/sessions/<session_id>?wfr=<execution_id>
+func (c *Client) SessionURL(name string) string {
+	out, err := c.run("test", "report", name, "--json")
+	if err != nil {
+		return ""
+	}
+	js := extractJSON(out)
+	if js == "" {
+		return ""
+	}
+	var r struct {
+		SessionID   string `json:"session_id"`
+		ExecutionID string `json:"execution_id"`
+	}
+	if json.Unmarshal([]byte(js), &r) != nil || r.SessionID == "" || r.ExecutionID == "" {
+		return ""
+	}
+	return fmt.Sprintf("https://app.revyl.ai/sessions/%s?wfr=%s", r.SessionID, r.ExecutionID)
 }
 
 // ReportShareURL returns a public shareable report link for the test's latest

--- a/internal/revyl/client.go
+++ b/internal/revyl/client.go
@@ -15,6 +15,14 @@ import (
 	"time"
 )
 
+// Onboarding constants for the Revyl activation funnel — surfaced when a
+// greenlight user reaches the runtime tier without a Revyl account.
+const (
+	SignupURL  = "https://app.revyl.ai/signup"
+	InstallCmd = "curl -fsSL https://revyl.com/install.sh | sh"
+	LoginCmd   = "revyl auth login"
+)
+
 // Client invokes the revyl CLI.
 type Client struct {
 	Bin string
@@ -47,6 +55,21 @@ func (c *Client) Available() error {
 		return nil
 	}
 	return fmt.Errorf("revyl CLI not found (looked for %q) — install it (https://docs.revyl.com) or pass --revyl <path>", c.Bin)
+}
+
+// Authenticated reports whether the user has a usable Revyl session. Used to
+// distinguish "needs to sign up / log in" from "the flow failed".
+func (c *Client) Authenticated() bool {
+	out, err := c.run("auth", "status")
+	l := strings.ToLower(out)
+	if strings.Contains(l, "not authenticated") || strings.Contains(l, "not logged in") ||
+		strings.Contains(l, "no credentials") || strings.Contains(l, "please log in") {
+		return false
+	}
+	if err != nil {
+		return false
+	}
+	return strings.Contains(l, "authenticated") || strings.Contains(l, "logged in")
 }
 
 // EnsureTest creates or updates a Revyl test from a YAML file. Idempotent via

--- a/internal/revyl/client.go
+++ b/internal/revyl/client.go
@@ -261,8 +261,20 @@ func parseReport(out string) (ReportResult, error) {
 	res.DeviceModel = j.DeviceModel
 	res.OSVersion = j.OSVersion
 	// StepsRun counts steps that actually executed (passed or failed). Zero means
-	// the flow never ran a step — a setup/launch failure, not a broken flow.
+	// the flow never ran a step — a setup/launch failure, not a broken flow. The
+	// passed/failed counts can lag the per-step statuses, so take the larger of
+	// the two signals.
 	res.StepsRun = j.PassedSteps + j.FailedSteps
+	terminal := 0
+	for _, s := range j.Steps {
+		switch strings.ToLower(firstNonEmpty(s.EffectiveStatus, s.Status)) {
+		case "passed", "pass", "failed", "fail", "error", "errored":
+			terminal++
+		}
+	}
+	if terminal > res.StepsRun {
+		res.StepsRun = terminal
+	}
 
 	// Prefer the explicit success boolean; fall back to session_status text.
 	if j.Success != nil {

--- a/internal/revyl/client.go
+++ b/internal/revyl/client.go
@@ -1,0 +1,228 @@
+// Package revyl is a thin wrapper around the `revyl` CLI binary. greenlight's
+// runtime tier shells out to it to drive flow validations on real devices. The
+// static scanners stay offline and zero-account; only `greenlight verify` reaches
+// for this — that separation is deliberate.
+package revyl
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// Client invokes the revyl CLI.
+type Client struct {
+	Bin string
+}
+
+// NewClient locates the revyl binary: explicit path, then $PATH, then the
+// default install location (~/.revyl/bin/revyl).
+func NewClient(bin string) *Client {
+	if bin != "" {
+		return &Client{Bin: bin}
+	}
+	if p, err := exec.LookPath("revyl"); err == nil {
+		return &Client{Bin: p}
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		cand := filepath.Join(home, ".revyl", "bin", "revyl")
+		if _, err := os.Stat(cand); err == nil {
+			return &Client{Bin: cand}
+		}
+	}
+	return &Client{Bin: "revyl"}
+}
+
+// Available returns an error if the revyl binary can't be found.
+func (c *Client) Available() error {
+	if _, err := exec.LookPath(c.Bin); err == nil {
+		return nil
+	}
+	if _, err := os.Stat(c.Bin); err == nil {
+		return nil
+	}
+	return fmt.Errorf("revyl CLI not found (looked for %q) — install it (https://docs.revyl.com) or pass --revyl <path>", c.Bin)
+}
+
+// EnsureTest creates or updates a Revyl test from a YAML file. Idempotent via
+// --force; --no-open keeps it headless.
+func (c *Client) EnsureTest(yamlPath string) (string, error) {
+	out, err := c.run("test", "create", "--from-file", yamlPath, "--no-open", "--force")
+	if err != nil {
+		return out, fmt.Errorf("revyl test create failed: %w\n%s", err, strings.TrimSpace(out))
+	}
+	return out, nil
+}
+
+// RunOpts configures a single test run.
+type RunOpts struct {
+	DeviceModel string
+	OSVersion   string
+	Build       bool // build+upload before running
+	Timeout     time.Duration
+}
+
+// RunResult is the outcome of a test run.
+type RunResult struct {
+	Passed     bool
+	FailedStep string
+	TaskID     string
+	Raw        string
+}
+
+// RunTest runs a test by name and interprets the outcome. The JSON field names
+// are best-effort across CLI versions; process exit code is the backstop signal.
+func (c *Client) RunTest(name string, opts RunOpts) (RunResult, error) {
+	args := []string{"test", "run", name, "--json"}
+	if opts.DeviceModel != "" {
+		args = append(args, "--device-model", opts.DeviceModel)
+	}
+	if opts.OSVersion != "" {
+		args = append(args, "--os-version", opts.OSVersion)
+	}
+	if opts.Build {
+		args = append(args, "--build")
+	}
+	if opts.Timeout > 0 {
+		args = append(args, "--timeout", fmt.Sprintf("%d", int(opts.Timeout.Seconds())))
+	}
+
+	out, runErr := c.run(args...)
+	res := RunResult{Raw: out}
+	exitOK := runErr == nil
+
+	var j runJSON
+	if jsonStr := extractJSON(out); jsonStr != "" {
+		_ = json.Unmarshal([]byte(jsonStr), &j)
+	}
+	res.TaskID = firstNonEmpty(j.TaskID, j.ID)
+
+	verdict, decided := j.verdict()
+	if decided {
+		res.Passed = verdict
+	} else {
+		res.Passed = exitOK
+	}
+	if !res.Passed {
+		res.FailedStep = j.firstFailedStep()
+	}
+
+	// Distinguish "the flow failed" (a real finding) from "couldn't run the flow"
+	// (auth/build/device setup) — the latter must never read as a passed or
+	// failed verdict.
+	if runErr != nil && !decided && looksLikeSetupError(out) {
+		return res, fmt.Errorf("revyl test run could not execute: %w\n%s", runErr, strings.TrimSpace(out))
+	}
+	return res, nil
+}
+
+// ReportShareURL returns a public shareable report link for the test's latest
+// run, best-effort (empty string if unavailable).
+func (c *Client) ReportShareURL(name string) string {
+	out, err := c.run("test", "report", name, "--share")
+	if err != nil {
+		return ""
+	}
+	return firstURL(out)
+}
+
+func (c *Client) run(args ...string) (string, error) {
+	cmd := exec.Command(c.Bin, args...)
+	cmd.Env = os.Environ()
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+// runJSON is a tolerant view of `revyl test run --json`.
+type runJSON struct {
+	Status  string `json:"status"`
+	Outcome string `json:"outcome"`
+	Result  string `json:"result"`
+	Passed  *bool  `json:"passed"`
+	Success *bool  `json:"success"`
+	TaskID  string `json:"task_id"`
+	ID      string `json:"id"`
+	Steps   []struct {
+		Status          string `json:"status"`
+		Passed          *bool  `json:"passed"`
+		Description     string `json:"description"`
+		StepDescription string `json:"step_description"`
+	} `json:"steps"`
+}
+
+func (j runJSON) verdict() (passed bool, decided bool) {
+	if j.Passed != nil {
+		return *j.Passed, true
+	}
+	if j.Success != nil {
+		return *j.Success, true
+	}
+	for _, s := range []string{j.Status, j.Outcome, j.Result} {
+		switch strings.ToLower(strings.TrimSpace(s)) {
+		case "passed", "pass", "success", "succeeded", "completed", "complete", "green":
+			return true, true
+		case "failed", "fail", "failure", "error", "errored", "red":
+			return false, true
+		}
+	}
+	return false, false
+}
+
+func (j runJSON) firstFailedStep() string {
+	for _, s := range j.Steps {
+		bad := s.Passed != nil && !*s.Passed
+		switch strings.ToLower(s.Status) {
+		case "failed", "fail", "error", "errored":
+			bad = true
+		}
+		if bad {
+			return firstNonEmpty(s.StepDescription, s.Description)
+		}
+	}
+	return ""
+}
+
+var (
+	reJSONURL = regexp.MustCompile(`https?://[^\s"']+`)
+)
+
+func extractJSON(s string) string {
+	i := strings.IndexByte(s, '{')
+	j := strings.LastIndexByte(s, '}')
+	if i >= 0 && j > i {
+		return s[i : j+1]
+	}
+	return ""
+}
+
+func firstURL(s string) string {
+	return reJSONURL.FindString(s)
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func looksLikeSetupError(s string) bool {
+	l := strings.ToLower(s)
+	for _, k := range []string{
+		"not authenticated", "unauthorized", "please log in", "auth login",
+		"no build", "build not found", "no device", "no runners", "not found",
+		"quota", "permission denied", "forbidden", "could not connect",
+	} {
+		if strings.Contains(l, k) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/revyl/client.go
+++ b/internal/revyl/client.go
@@ -131,6 +131,90 @@ func (c *Client) ReportShareURL(name string) string {
 	return firstURL(out)
 }
 
+// ReportResult is the authoritative outcome of a test's latest execution,
+// extracted from `revyl test report --json`. session_status is Revyl's verdict;
+// the failing step's description and reason are the evidence a static scanner
+// can never produce.
+type ReportResult struct {
+	Decided      bool
+	Passed       bool
+	FailedStep   string
+	FailedReason string
+	ReportURL    string
+	DeviceModel  string
+	OSVersion    string
+}
+
+// reportJSON mirrors the real `revyl test report --json` schema.
+type reportJSON struct {
+	SessionStatus string `json:"session_status"`
+	ReportURL     string `json:"report_url"`
+	DeviceModel   string `json:"device_model"`
+	OSVersion     string `json:"os_version"`
+	Steps         []struct {
+		Status                string `json:"status"`
+		EffectiveStatus       string `json:"effective_status"`
+		StepDescription       string `json:"step_description"`
+		StatusReason          string `json:"status_reason"`
+		EffectiveStatusReason string `json:"effective_status_reason"`
+		ExecutionOrder        int    `json:"execution_order"`
+	} `json:"steps"`
+}
+
+// Report fetches the latest execution report for a test and extracts the
+// authoritative verdict plus the first failing step (description + reason).
+func (c *Client) Report(name string) (ReportResult, error) {
+	out, err := c.run("test", "report", name, "--json")
+	if err != nil {
+		return ReportResult{}, fmt.Errorf("revyl test report failed: %w\n%s", err, strings.TrimSpace(out))
+	}
+	return parseReport(out)
+}
+
+// parseReport extracts a verdict + failing-step evidence from the raw output of
+// `revyl test report --json`. Factored out for testing against the real schema.
+func parseReport(out string) (ReportResult, error) {
+	var res ReportResult
+	var j reportJSON
+	if js := extractJSON(out); js != "" {
+		if e := json.Unmarshal([]byte(js), &j); e != nil {
+			return res, fmt.Errorf("could not parse report JSON: %w", e)
+		}
+	}
+
+	res.ReportURL = j.ReportURL
+	res.DeviceModel = j.DeviceModel
+	res.OSVersion = j.OSVersion
+
+	switch strings.ToLower(strings.TrimSpace(j.SessionStatus)) {
+	case "passed", "pass", "success", "succeeded", "completed", "complete", "green":
+		res.Passed, res.Decided = true, true
+	case "failed", "fail", "failure", "error", "errored", "red":
+		res.Passed, res.Decided = false, true
+	}
+
+	for _, s := range j.Steps {
+		switch strings.ToLower(firstNonEmpty(s.EffectiveStatus, s.Status)) {
+		case "failed", "fail", "error", "errored":
+			res.FailedStep = s.StepDescription
+			res.FailedReason = cleanReason(firstNonEmpty(s.StatusReason, s.EffectiveStatusReason))
+			return res, nil
+		}
+	}
+	return res, nil
+}
+
+// cleanReason trims Revyl's verbose step failure reason to a single readable line.
+func cleanReason(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.TrimPrefix(s, "Step execution failed: ")
+	s = strings.TrimSpace(s)
+	if len(s) > 180 {
+		s = s[:177] + "..."
+	}
+	return s
+}
+
 func (c *Client) run(args ...string) (string, error) {
 	cmd := exec.Command(c.Bin, args...)
 	cmd.Env = os.Environ()

--- a/internal/revyl/client.go
+++ b/internal/revyl/client.go
@@ -64,13 +64,13 @@ func (c *Client) Authenticated() bool {
 	out, err := c.run("auth", "status")
 	l := strings.ToLower(out)
 	if strings.Contains(l, "not authenticated") || strings.Contains(l, "not logged in") ||
-		strings.Contains(l, "no credentials") || strings.Contains(l, "please log in") {
+		strings.Contains(l, "no credentials") || strings.Contains(l, "please log in") ||
+		strings.Contains(l, "logged out") {
 		return false
 	}
-	if err != nil {
-		return false
-	}
-	return strings.Contains(l, "authenticated") || strings.Contains(l, "logged in")
+	// Otherwise trust the exit code: `revyl auth status` succeeds when signed in.
+	// (Don't require a specific success word — the wording/format can change.)
+	return err == nil
 }
 
 // AppID resolves a registered build/app name to its Revyl app id. Passing the id
@@ -377,11 +377,44 @@ var (
 	reJSONURL = regexp.MustCompile(`https?://[^\s"']+`)
 )
 
+// extractJSON returns the first balanced JSON object or array in s, ignoring
+// surrounding spinner/log output and braces inside later log lines. It respects
+// string literals so braces/quotes inside JSON strings don't confuse the scan.
 func extractJSON(s string) string {
-	i := strings.IndexByte(s, '{')
-	j := strings.LastIndexByte(s, '}')
-	if i >= 0 && j > i {
-		return s[i : j+1]
+	start := strings.IndexAny(s, "{[")
+	if start < 0 {
+		return ""
+	}
+	open := s[start]
+	closeB := byte('}')
+	if open == '[' {
+		closeB = ']'
+	}
+	depth, inStr, esc := 0, false, false
+	for i := start; i < len(s); i++ {
+		c := s[i]
+		if inStr {
+			switch {
+			case esc:
+				esc = false
+			case c == '\\':
+				esc = true
+			case c == '"':
+				inStr = false
+			}
+			continue
+		}
+		switch c {
+		case '"':
+			inStr = true
+		case open:
+			depth++
+		case closeB:
+			depth--
+			if depth == 0 {
+				return s[start : i+1]
+			}
+		}
 	}
 	return ""
 }

--- a/internal/revyl/client.go
+++ b/internal/revyl/client.go
@@ -308,8 +308,8 @@ func cleanReason(s string) string {
 	s = strings.TrimSpace(s)
 	s = strings.TrimPrefix(s, "Step execution failed: ")
 	s = strings.TrimSpace(s)
-	if len(s) > 180 {
-		s = s[:177] + "..."
+	if r := []rune(s); len(r) > 180 {
+		s = string(r[:177]) + "..."
 	}
 	return s
 }

--- a/internal/revyl/client.go
+++ b/internal/revyl/client.go
@@ -1,5 +1,5 @@
 // Package revyl is a thin wrapper around the `revyl` CLI binary. greenlight's
-// runtime tier shells out to it to drive flow validations on real devices. The
+// runtime tier shells out to it to drive flow validations on cloud devices. The
 // static scanners stay offline and zero-account; only `greenlight verify` reaches
 // for this — that separation is deliberate.
 package revyl

--- a/internal/revyl/client_test.go
+++ b/internal/revyl/client_test.go
@@ -1,0 +1,88 @@
+package revyl
+
+import "testing"
+
+// sampleFailedReport is a trimmed slice of a real `revyl test report --json`
+// response (captured from a live device run), exercising the exact field names
+// the parser depends on.
+const sampleFailedReport = `{
+  "app_name": "Spootify",
+  "device_model": "iPhone 17 Pro Max",
+  "os_version": "iOS 26.2",
+  "session_status": "failed",
+  "failed_steps": 1,
+  "passed_steps": 0,
+  "execution_id": "b990b41a-f777-4239-8701-65535e3cf565",
+  "report_url": "https://app.revyl.ai/tests/report?taskId=b990b41a-f777-4239-8701-65535e3cf565",
+  "steps": [
+    {
+      "execution_order": 0,
+      "status": "failed",
+      "effective_status": "failed",
+      "step_description": "Go to the login screen",
+      "status_reason": "Step execution failed: Failed to open URL spotify://login: Failed to open URL spotify://login on simulator",
+      "step_type": "instruction"
+    }
+  ]
+}`
+
+const samplePassedReport = `{
+  "session_status": "passed",
+  "report_url": "https://app.revyl.ai/tests/report?taskId=abc",
+  "steps": [
+    {"execution_order": 0, "status": "passed", "step_description": "Go to the login screen"}
+  ]
+}`
+
+func TestParseReportFailed(t *testing.T) {
+	r, err := parseReport(sampleFailedReport)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !r.Decided || r.Passed {
+		t.Errorf("expected a decided failure, got Decided=%v Passed=%v", r.Decided, r.Passed)
+	}
+	if r.FailedStep != "Go to the login screen" {
+		t.Errorf("FailedStep = %q, want %q", r.FailedStep, "Go to the login screen")
+	}
+	if r.FailedReason == "" || len(r.FailedReason) > 180 {
+		t.Errorf("FailedReason not extracted/cleaned: %q", r.FailedReason)
+	}
+	// cleanReason strips the "Step execution failed: " prefix.
+	if want := "Failed to open URL"; r.FailedReason[:len(want)] != want {
+		t.Errorf("FailedReason = %q, want it to start with %q", r.FailedReason, want)
+	}
+	if r.ReportURL == "" {
+		t.Errorf("ReportURL not extracted")
+	}
+	if r.DeviceModel != "iPhone 17 Pro Max" || r.OSVersion != "iOS 26.2" {
+		t.Errorf("device context not extracted: %q / %q", r.DeviceModel, r.OSVersion)
+	}
+}
+
+func TestParseReportPassed(t *testing.T) {
+	r, err := parseReport(samplePassedReport)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !r.Decided || !r.Passed {
+		t.Errorf("expected a decided pass, got Decided=%v Passed=%v", r.Decided, r.Passed)
+	}
+	if r.FailedStep != "" {
+		t.Errorf("expected no failed step on a pass, got %q", r.FailedStep)
+	}
+}
+
+func TestVerdictAndStepFromRunJSON(t *testing.T) {
+	// Exit-code is the backstop, but explicit JSON verdicts should win when present.
+	pass := true
+	if v, decided := (runJSON{Passed: &pass}).verdict(); !decided || !v {
+		t.Errorf("explicit passed=true not honored: v=%v decided=%v", v, decided)
+	}
+	if v, decided := (runJSON{Status: "failed"}).verdict(); !decided || v {
+		t.Errorf("status=failed not honored: v=%v decided=%v", v, decided)
+	}
+	if _, decided := (runJSON{}).verdict(); decided {
+		t.Errorf("empty runJSON should be undecided (fall back to exit code)")
+	}
+}

--- a/internal/revyl/client_test.go
+++ b/internal/revyl/client_test.go
@@ -10,6 +10,8 @@ const sampleFailedReport = `{
   "device_model": "iPhone 17 Pro Max",
   "os_version": "iOS 26.2",
   "session_status": "failed",
+  "success": false,
+  "total_steps": 1,
   "failed_steps": 1,
   "passed_steps": 0,
   "execution_id": "b990b41a-f777-4239-8701-65535e3cf565",
@@ -28,10 +30,29 @@ const sampleFailedReport = `{
 
 const samplePassedReport = `{
   "session_status": "passed",
+  "success": true,
+  "total_steps": 1,
+  "passed_steps": 1,
   "report_url": "https://app.revyl.ai/tests/report?taskId=abc",
   "steps": [
     {"execution_order": 0, "status": "passed", "step_description": "Go to the login screen"}
   ]
+}`
+
+// sampleSetupFailure is the real amazoon case: the run "failed" but executed
+// ZERO steps (build failed to install/launch). This must NOT read as a broken
+// flow — the runner reclassifies a 0-step failure as a setup error.
+const sampleSetupFailure = `{
+  "app_name": "amazoon",
+  "device_model": "iPhone 17 Pro Max",
+  "os_version": "iOS 26.2",
+  "session_status": "failed",
+  "success": false,
+  "total_steps": 0,
+  "failed_steps": 0,
+  "passed_steps": 0,
+  "report_url": "https://app.revyl.ai/tests/report?taskId=1a04ac9e-894e-48f2-8ef3-54692700feb4",
+  "steps": []
 }`
 
 func TestParseReportFailed(t *testing.T) {
@@ -55,8 +76,26 @@ func TestParseReportFailed(t *testing.T) {
 	if r.ReportURL == "" {
 		t.Errorf("ReportURL not extracted")
 	}
+	if r.StepsRun != 1 {
+		t.Errorf("StepsRun = %d, want 1", r.StepsRun)
+	}
 	if r.DeviceModel != "iPhone 17 Pro Max" || r.OSVersion != "iOS 26.2" {
 		t.Errorf("device context not extracted: %q / %q", r.DeviceModel, r.OSVersion)
+	}
+}
+
+// TestParseReportSetupFailure pins the amazoon regression: a failed run that
+// executed zero steps is a setup/launch failure, distinguishable via StepsRun==0.
+func TestParseReportSetupFailure(t *testing.T) {
+	r, err := parseReport(sampleSetupFailure)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !r.Decided || r.Passed {
+		t.Errorf("expected a decided failure, got Decided=%v Passed=%v", r.Decided, r.Passed)
+	}
+	if r.StepsRun != 0 {
+		t.Errorf("StepsRun = %d, want 0 (the runner uses this to flag a setup failure, not a broken flow)", r.StepsRun)
 	}
 }
 

--- a/internal/revyl/client_test.go
+++ b/internal/revyl/client_test.go
@@ -112,6 +112,16 @@ func TestParseReportPassed(t *testing.T) {
 	}
 }
 
+// extractJSON must return the balanced JSON object, ignoring a '}' inside a
+// string value and any trailing log line that contains braces.
+func TestExtractJSONIgnoresTrailingBraces(t *testing.T) {
+	got := extractJSON("{\"a\":1,\"b\":\"x}y\"}\nWARN trailing }brace")
+	want := `{"a":1,"b":"x}y"}`
+	if got != want {
+		t.Errorf("extractJSON = %q, want %q", got, want)
+	}
+}
+
 func TestVerdictAndStepFromRunJSON(t *testing.T) {
 	// Exit-code is the backstop, but explicit JSON verdicts should win when present.
 	pass := true

--- a/internal/verify/flows.go
+++ b/internal/verify/flows.go
@@ -16,7 +16,6 @@ type Flow struct {
 	ID          string
 	Guideline   string
 	Title       string
-	TestName    string // stable Revyl test name (idempotent create)
 	StaticRule  string // the codescan rule id this corresponds to
 	AntiPattern string // the source string that makes static PASS (for the message)
 	Steps       []Step
@@ -39,7 +38,6 @@ func AllFlows() []Flow {
 			ID:           "account-deletion",
 			Guideline:    "5.1.1",
 			Title:        "Account deletion must actually delete the account",
-			TestName:     "greenlight-account-deletion",
 			StaticRule:   "account-no-delete",
 			AntiPattern:  "deleteAccount",
 			claimed:      func(c codescan.Claims) bool { return c.AccountCreation },
@@ -56,7 +54,6 @@ func AllFlows() []Flow {
 			ID:           "restore-purchases",
 			Guideline:    "3.1.1",
 			Title:        "Restore Purchases must trigger a real restore",
-			TestName:     "greenlight-restore-purchases",
 			StaticRule:   "iap-no-restore",
 			AntiPattern:  "restorePurchases",
 			claimed:      func(c codescan.Claims) bool { return c.IAP },
@@ -71,7 +68,6 @@ func AllFlows() []Flow {
 			ID:           "sign-in-apple",
 			Guideline:    "4.8",
 			Title:        "Sign in with Apple must actually start Apple sign-in",
-			TestName:     "greenlight-sign-in-with-apple",
 			StaticRule:   "social-login-no-apple",
 			AntiPattern:  "Sign in with Apple",
 			claimed:      func(c codescan.Claims) bool { return c.SocialLogin },

--- a/internal/verify/flows.go
+++ b/internal/verify/flows.go
@@ -1,0 +1,87 @@
+package verify
+
+import "github.com/RevylAI/greenlight/internal/codescan"
+
+// Step is one block in a generated Revyl test.
+type Step struct {
+	Type         string // "instructions" | "validation" | "extraction"
+	Desc         string
+	VariableName string // for extraction steps only
+}
+
+// Flow is a flow-dependent App Store guideline. Static analysis can only confirm
+// it by string presence; this tier re-checks it on a real device. Each flow maps
+// to one codescan rule whose anti-pattern suppression is the false-negative risk.
+type Flow struct {
+	ID          string
+	Guideline   string
+	Title       string
+	TestName    string // stable Revyl test name (idempotent create)
+	StaticRule  string // the codescan rule id this corresponds to
+	AntiPattern string // the source string that makes static PASS (for the message)
+	Steps       []Step
+
+	claimed      func(codescan.Claims) bool
+	staticPassed func(codescan.Claims) bool
+}
+
+// Claimed reports whether the app claims this feature (so the flow is worth running).
+func (f Flow) Claimed(c codescan.Claims) bool { return f.claimed(c) }
+
+// StaticPassed reports whether the static scanner would have GREENLIT this flow —
+// i.e. the anti-pattern code is present. Frames the "static said ship it" message.
+func (f Flow) StaticPassed(c codescan.Claims) bool { return f.staticPassed(c) }
+
+// AllFlows returns the runtime-verifiable flows, ordered by rejection impact.
+func AllFlows() []Flow {
+	return []Flow{
+		{
+			ID:           "account-deletion",
+			Guideline:    "5.1.1",
+			Title:        "Account deletion must actually delete the account",
+			TestName:     "greenlight-account-deletion",
+			StaticRule:   "account-no-delete",
+			AntiPattern:  "deleteAccount",
+			claimed:      func(c codescan.Claims) bool { return c.AccountCreation },
+			staticPassed: func(c codescan.Claims) bool { return c.HasDeleteAccountCode },
+			Steps: []Step{
+				{Type: "instructions", Desc: "Log in with {{email}} and {{password}}"},
+				{Type: "instructions", Desc: "Open the account or settings screen"},
+				{Type: "instructions", Desc: "Tap 'Delete Account' and confirm any prompt to permanently delete the account"},
+				{Type: "validation", Desc: "The app returns to a logged-out / sign-in screen after the deletion"},
+				{Type: "validation", Desc: "Logging in again with {{email}} and {{password}} is rejected — the account no longer exists"},
+			},
+		},
+		{
+			ID:           "restore-purchases",
+			Guideline:    "3.1.1",
+			Title:        "Restore Purchases must trigger a real restore",
+			TestName:     "greenlight-restore-purchases",
+			StaticRule:   "iap-no-restore",
+			AntiPattern:  "restorePurchases",
+			claimed:      func(c codescan.Claims) bool { return c.IAP },
+			staticPassed: func(c codescan.Claims) bool { return c.HasRestoreCode },
+			Steps: []Step{
+				{Type: "instructions", Desc: "Navigate to the paywall, store, or subscription settings screen"},
+				{Type: "instructions", Desc: "Tap the 'Restore Purchases' button"},
+				{Type: "validation", Desc: "Restore Purchases produces a visible response — a system restore prompt, a success or no-purchases message, or restored entitlements — and is not a silent no-op"},
+			},
+		},
+		{
+			ID:           "sign-in-apple",
+			Guideline:    "4.8",
+			Title:        "Sign in with Apple must actually start Apple sign-in",
+			TestName:     "greenlight-sign-in-with-apple",
+			StaticRule:   "social-login-no-apple",
+			AntiPattern:  "Sign in with Apple",
+			claimed:      func(c codescan.Claims) bool { return c.SocialLogin },
+			staticPassed: func(c codescan.Claims) bool { return c.HasSignInWithApple },
+			Steps: []Step{
+				{Type: "instructions", Desc: "Go to the login screen"},
+				{Type: "validation", Desc: "A 'Sign in with Apple' button is visible on the login screen"},
+				{Type: "instructions", Desc: "Tap the 'Sign in with Apple' button"},
+				{Type: "validation", Desc: "The native Apple sign-in sheet appears — the button is not a dead control"},
+			},
+		},
+	}
+}

--- a/internal/verify/flows.go
+++ b/internal/verify/flows.go
@@ -10,7 +10,7 @@ type Step struct {
 }
 
 // Flow is a flow-dependent App Store guideline. Static analysis can only confirm
-// it by string presence; this tier re-checks it on a real device. Each flow maps
+// it by string presence; this tier re-checks it on a cloud device. Each flow maps
 // to one codescan rule whose anti-pattern suppression is the false-negative risk.
 type Flow struct {
 	ID          string

--- a/internal/verify/render.go
+++ b/internal/verify/render.go
@@ -1,0 +1,49 @@
+package verify
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// renderTestYAML produces a Revyl test YAML document for a flow, matching the
+// schema at https://docs.revyl.com/appendix/yaml-test-format.
+func renderTestYAML(f Flow, platform, buildName string, vars map[string]string) string {
+	var b strings.Builder
+	b.WriteString("test:\n")
+	b.WriteString("  metadata:\n")
+	fmt.Fprintf(&b, "    name: %s\n", yamlStr(f.TestName))
+	fmt.Fprintf(&b, "    platform: %s\n", platform)
+	b.WriteString("    tags:\n")
+	b.WriteString("      - greenlight\n")
+	b.WriteString("      - runtime\n")
+	if len(vars) > 0 {
+		b.WriteString("    variables:\n")
+		keys := make([]string, 0, len(vars))
+		for k := range vars {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			fmt.Fprintf(&b, "      %s: %s\n", k, yamlStr(vars[k]))
+		}
+	}
+	b.WriteString("  build:\n")
+	fmt.Fprintf(&b, "    name: %s\n", yamlStr(buildName))
+	b.WriteString("  blocks:\n")
+	for _, s := range f.Steps {
+		fmt.Fprintf(&b, "    - type: %s\n", s.Type)
+		fmt.Fprintf(&b, "      step_description: %s\n", yamlStr(s.Desc))
+		if s.Type == "extraction" && s.VariableName != "" {
+			fmt.Fprintf(&b, "      variable_name: %s\n", yamlStr(s.VariableName))
+		}
+	}
+	return b.String()
+}
+
+// yamlStr returns a safely double-quoted YAML scalar.
+func yamlStr(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `"`, `\"`)
+	return `"` + s + `"`
+}

--- a/internal/verify/render.go
+++ b/internal/verify/render.go
@@ -2,7 +2,6 @@ package verify
 
 import (
 	"fmt"
-	"sort"
 	"strings"
 )
 
@@ -10,6 +9,11 @@ import (
 // schema at https://docs.revyl.com/appendix/yaml-test-format. The test name is
 // passed in (not Flow.TestName) so it can be made unique per build — a stable
 // name across apps gets silently rebound to the first app's build.
+//
+// Credential values are inlined directly into step text rather than emitted as a
+// `variables:` block: Revyl treats metadata.variables as launch-time values, and
+// for apps that don't expect them the app fails to launch (the run records zero
+// steps). Inlining keeps the launch clean and the steps self-contained.
 func renderTestYAML(f Flow, name, platform, buildName string, vars map[string]string) string {
 	var b strings.Builder
 	b.WriteString("test:\n")
@@ -19,28 +23,26 @@ func renderTestYAML(f Flow, name, platform, buildName string, vars map[string]st
 	b.WriteString("    tags:\n")
 	b.WriteString("      - greenlight\n")
 	b.WriteString("      - runtime\n")
-	if len(vars) > 0 {
-		b.WriteString("    variables:\n")
-		keys := make([]string, 0, len(vars))
-		for k := range vars {
-			keys = append(keys, k)
-		}
-		sort.Strings(keys)
-		for _, k := range keys {
-			fmt.Fprintf(&b, "      %s: %s\n", k, yamlStr(vars[k]))
-		}
-	}
 	b.WriteString("  build:\n")
 	fmt.Fprintf(&b, "    name: %s\n", yamlStr(buildName))
 	b.WriteString("  blocks:\n")
 	for _, s := range f.Steps {
 		fmt.Fprintf(&b, "    - type: %s\n", s.Type)
-		fmt.Fprintf(&b, "      step_description: %s\n", yamlStr(s.Desc))
+		fmt.Fprintf(&b, "      step_description: %s\n", yamlStr(substituteVars(s.Desc, vars)))
 		if s.Type == "extraction" && s.VariableName != "" {
 			fmt.Fprintf(&b, "      variable_name: %s\n", yamlStr(s.VariableName))
 		}
 	}
 	return b.String()
+}
+
+// substituteVars replaces {{key}} placeholders with their provided values.
+// Unprovided placeholders are left as-is.
+func substituteVars(s string, vars map[string]string) string {
+	for k, v := range vars {
+		s = strings.ReplaceAll(s, "{{"+k+"}}", v)
+	}
+	return s
 }
 
 // yamlStr returns a safely double-quoted YAML scalar.

--- a/internal/verify/render.go
+++ b/internal/verify/render.go
@@ -7,12 +7,14 @@ import (
 )
 
 // renderTestYAML produces a Revyl test YAML document for a flow, matching the
-// schema at https://docs.revyl.com/appendix/yaml-test-format.
-func renderTestYAML(f Flow, platform, buildName string, vars map[string]string) string {
+// schema at https://docs.revyl.com/appendix/yaml-test-format. The test name is
+// passed in (not Flow.TestName) so it can be made unique per build — a stable
+// name across apps gets silently rebound to the first app's build.
+func renderTestYAML(f Flow, name, platform, buildName string, vars map[string]string) string {
 	var b strings.Builder
 	b.WriteString("test:\n")
 	b.WriteString("  metadata:\n")
-	fmt.Fprintf(&b, "    name: %s\n", yamlStr(f.TestName))
+	fmt.Fprintf(&b, "    name: %s\n", yamlStr(name))
 	fmt.Fprintf(&b, "    platform: %s\n", platform)
 	b.WriteString("    tags:\n")
 	b.WriteString("      - greenlight\n")

--- a/internal/verify/render.go
+++ b/internal/verify/render.go
@@ -19,7 +19,7 @@ func renderTestYAML(f Flow, name, platform, buildName string, vars map[string]st
 	b.WriteString("test:\n")
 	b.WriteString("  metadata:\n")
 	fmt.Fprintf(&b, "    name: %s\n", yamlStr(name))
-	fmt.Fprintf(&b, "    platform: %s\n", platform)
+	fmt.Fprintf(&b, "    platform: %s\n", yamlStr(platform))
 	b.WriteString("    tags:\n")
 	b.WriteString("      - greenlight\n")
 	b.WriteString("      - runtime\n")
@@ -45,9 +45,14 @@ func substituteVars(s string, vars map[string]string) string {
 	return s
 }
 
-// yamlStr returns a safely double-quoted YAML scalar.
+// yamlStr returns a safely double-quoted YAML scalar. Backslashes are escaped
+// first, then quotes, then control characters are converted to their escape
+// sequences (a raw newline/tab/CR would otherwise terminate or corrupt the scalar).
 func yamlStr(s string) string {
 	s = strings.ReplaceAll(s, `\`, `\\`)
 	s = strings.ReplaceAll(s, `"`, `\"`)
+	s = strings.ReplaceAll(s, "\n", `\n`)
+	s = strings.ReplaceAll(s, "\r", `\r`)
+	s = strings.ReplaceAll(s, "\t", `\t`)
 	return `"` + s + `"`
 }

--- a/internal/verify/runner.go
+++ b/internal/verify/runner.go
@@ -16,8 +16,23 @@ const (
 	StatusVerified = "verified" // ran on-device and behaved correctly
 	StatusFailed   = "failed"   // ran on-device and the flow broke (the catch)
 	StatusSkipped  = "skipped"  // feature not claimed, or dry-run
-	StatusError    = "error"    // could not run (auth/build/device/setup)
+	StatusError    = "error"    // could not run (build/device/setup)
+	StatusPending  = "pending"  // claimed, but blocked behind Revyl sign-up
 )
+
+// Onboarding reasons — why the runtime tier needs the user to set up Revyl.
+const (
+	OnboardCLIMissing       = "cli-missing"
+	OnboardNotAuthenticated = "not-authenticated"
+)
+
+// Onboarding is set when the user reached the runtime tier without a usable
+// Revyl account. It drives the sign-up call-to-action — the greenlight->Revyl
+// activation funnel.
+type Onboarding struct {
+	Reason  string `json:"reason"`
+	Message string `json:"message,omitempty"`
+}
 
 // Config controls a verify run.
 type Config struct {
@@ -57,7 +72,8 @@ type Summary struct {
 	Failed   int  `json:"failed"`
 	Errored  int  `json:"errored"`
 	Skipped  int  `json:"skipped"`
-	Passed   bool `json:"passed"` // true iff zero failed and zero errored
+	Pending  int  `json:"pending"` // claimed but blocked behind Revyl sign-up
+	Passed   bool `json:"passed"`  // true iff zero failed and zero errored
 }
 
 // Result is the full verify report.
@@ -67,6 +83,7 @@ type Result struct {
 	Claims      codescan.Claims `json:"claims"`
 	Flows       []FlowResult    `json:"flows"`
 	Summary     Summary         `json:"summary"`
+	Onboarding  *Onboarding     `json:"onboarding,omitempty"`
 	DryRun      bool            `json:"dry_run"`
 	Elapsed     time.Duration   `json:"-"`
 }
@@ -93,6 +110,16 @@ func Run(cfg Config) (*Result, error) {
 
 	selected := selectedSet(cfg.Flows)
 	client := revyl.NewClient(cfg.RevylBin)
+
+	// Determine Revyl readiness once. If the user has no usable account, we
+	// don't error per-flow — we surface a single sign-up call-to-action.
+	if !cfg.DryRun {
+		if err := client.Available(); err != nil {
+			res.Onboarding = &Onboarding{Reason: OnboardCLIMissing, Message: err.Error()}
+		} else if !client.Authenticated() {
+			res.Onboarding = &Onboarding{Reason: OnboardNotAuthenticated}
+		}
+	}
 
 	for _, f := range AllFlows() {
 		if len(selected) > 0 && !selected[f.ID] {
@@ -122,15 +149,17 @@ func Run(cfg Config) (*Result, error) {
 			continue
 		}
 
-		if cfg.BuildName == "" {
-			fr.Status = StatusError
-			fr.Detail = "no --build-name provided; cannot map the test to a registered Revyl build"
+		// No usable Revyl account → pending behind sign-up (see res.Onboarding).
+		if res.Onboarding != nil {
+			fr.Status = StatusPending
+			fr.Detail = "sign up for Revyl to validate this flow on a real device"
 			res.Flows = append(res.Flows, fr)
 			continue
 		}
-		if err := client.Available(); err != nil {
+
+		if cfg.BuildName == "" {
 			fr.Status = StatusError
-			fr.Detail = err.Error()
+			fr.Detail = "no --build-name provided; cannot map the test to a registered Revyl build"
 			res.Flows = append(res.Flows, fr)
 			continue
 		}
@@ -232,6 +261,8 @@ func summarize(flows []FlowResult) Summary {
 			s.Errored++
 		case StatusSkipped:
 			s.Skipped++
+		case StatusPending:
+			s.Pending++
 		}
 	}
 	s.Passed = s.Failed == 0 && s.Errored == 0

--- a/internal/verify/runner.go
+++ b/internal/verify/runner.go
@@ -158,10 +158,12 @@ func Run(cfg Config) (*Result, error) {
 			continue
 		}
 
-		// Unique test name per build — a stable name gets silently rebound to
-		// the first app's build by `revyl test create --force`.
+		// Unique test name per build: a stable name gets silently rebound to the
+		// first app's build by `revyl test create --force`.
 		tname := testName(cfg.BuildName, f.ID)
-		fr.YAML = renderTestYAML(f, tname, platform, cfg.BuildName, cfg.Vars)
+		// The displayed/dry-run YAML redacts secret vars; the executed YAML
+		// (written to the temp file below) uses the real values.
+		fr.YAML = renderTestYAML(f, tname, platform, cfg.BuildName, redactVarsMap(cfg.Vars))
 
 		if cfg.DryRun {
 			fr.Status = StatusSkipped
@@ -194,7 +196,8 @@ func Run(cfg Config) (*Result, error) {
 			continue
 		}
 
-		path, werr := writeTempYAML(tname, fr.YAML)
+		realYAML := renderTestYAML(f, tname, platform, cfg.BuildName, cfg.Vars)
+		path, werr := writeTempYAML(tname, realYAML)
 		if werr != nil {
 			fr.Status = StatusError
 			fr.Detail = "could not stage test file: " + werr.Error()
@@ -230,7 +233,7 @@ func Run(cfg Config) (*Result, error) {
 		// failing step + reason are the evidence. `revyl test run` can return a
 		// moment before the report finalizes, so poll briefly until it settles.
 		report, repErr := client.Report(tname)
-		for tries := 0; !report.Decided && tries < 12; tries++ {
+		for tries := 0; repErr == nil && !report.Decided && tries < 12; tries++ {
 			time.Sleep(3 * time.Second)
 			report, repErr = client.Report(tname)
 		}
@@ -308,6 +311,23 @@ func redactVars(s string, vars map[string]string) string {
 		}
 	}
 	return s
+}
+
+// redactVarsMap returns a copy of vars with sensitive values replaced, for the
+// displayed/dry-run YAML (the executed YAML still uses the real values).
+func redactVarsMap(vars map[string]string) map[string]string {
+	if len(vars) == 0 {
+		return vars
+	}
+	out := make(map[string]string, len(vars))
+	for k, v := range vars {
+		if v != "" && isSensitiveKey(k) {
+			out[k] = "[redacted]"
+		} else {
+			out[k] = v
+		}
+	}
+	return out
 }
 
 func isSensitiveKey(k string) bool {

--- a/internal/verify/runner.go
+++ b/internal/verify/runner.go
@@ -218,21 +218,24 @@ func Run(cfg Config) (*Result, error) {
 		// Enrich with the execution report: the verdict is Revyl's, and the
 		// failing step + reason are the evidence. `revyl test run` can return a
 		// moment before the report finalizes, so poll briefly until it settles.
-		report, _ := client.Report(tname)
+		report, repErr := client.Report(tname)
 		for tries := 0; !report.Decided && tries < 12; tries++ {
 			time.Sleep(3 * time.Second)
-			report, _ = client.Report(tname)
+			report, repErr = client.Report(tname)
 		}
 		reportURL := firstNonEmptyStr(client.ReportShareURL(tname), report.ReportURL)
 
 		switch {
 		case !report.Decided:
-			// The report never finalized: we can't confirm the outcome either way
-			// (a passing OR failing exit code alone is not authoritative). Don't
-			// claim VERIFIED or FAILED on an unknown report.
+			// The report never finalized (or couldn't be fetched): we can't
+			// confirm the outcome either way, so don't claim VERIFIED or FAILED.
 			fr.Status = StatusError
 			fr.ReportURL = reportURL
-			fr.Detail = "could not determine the outcome: the Revyl report did not finalize. Rerun, or open the report."
+			if repErr != nil {
+				fr.Detail = "could not read the Revyl report: " + repErr.Error()
+			} else {
+				fr.Detail = "could not determine the outcome: the Revyl report did not finalize. Rerun, or open the report."
+			}
 		case report.Passed:
 			fr.Status = StatusVerified
 			fr.Detail = "flow ran on-device and behaved correctly"
@@ -349,6 +352,7 @@ func writeTempYAML(name, content string) (string, error) {
 	}
 	path := filepath.Join(dir, name+".yaml")
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		os.RemoveAll(dir)
 		return "", err
 	}
 	return path, nil

--- a/internal/verify/runner.go
+++ b/internal/verify/runner.go
@@ -121,6 +121,12 @@ func Run(cfg Config) (*Result, error) {
 		}
 	}
 
+	// Resolve the build name to an app id once — `test create --app` needs it.
+	var appID string
+	if res.Onboarding == nil && !cfg.DryRun && cfg.BuildName != "" {
+		appID, _ = client.AppID(cfg.BuildName)
+	}
+
 	for _, f := range AllFlows() {
 		if len(selected) > 0 && !selected[f.ID] {
 			continue
@@ -166,6 +172,12 @@ func Run(cfg Config) (*Result, error) {
 			res.Flows = append(res.Flows, fr)
 			continue
 		}
+		if appID == "" {
+			fr.Status = StatusError
+			fr.Detail = fmt.Sprintf("no Revyl app found matching build name %q — check `revyl app list`", cfg.BuildName)
+			res.Flows = append(res.Flows, fr)
+			continue
+		}
 
 		path, werr := writeTempYAML(tname, fr.YAML)
 		if werr != nil {
@@ -175,7 +187,7 @@ func Run(cfg Config) (*Result, error) {
 			continue
 		}
 
-		if _, cerr := client.EnsureTest(path); cerr != nil {
+		if _, cerr := client.EnsureTest(tname, path, appID); cerr != nil {
 			fr.Status = StatusError
 			fr.Detail = cerr.Error()
 			cleanupTemp(path)

--- a/internal/verify/runner.go
+++ b/internal/verify/runner.go
@@ -111,9 +111,20 @@ func Run(cfg Config) (*Result, error) {
 	selected := selectedSet(cfg.Flows)
 	client := revyl.NewClient(cfg.RevylBin)
 
+	// Only engage the Revyl runtime tier if at least one selected flow is
+	// actually claimed. Otherwise there is nothing to verify, and we must not
+	// prompt for sign-up/auth or show a CTA with 0 flows.
+	anyClaimed := false
+	for _, f := range AllFlows() {
+		if (len(selected) == 0 || selected[f.ID]) && f.Claimed(claims) {
+			anyClaimed = true
+			break
+		}
+	}
+
 	// Determine Revyl readiness once. If the user has no usable account, we
-	// don't error per-flow — we surface a single sign-up call-to-action.
-	if !cfg.DryRun {
+	// don't error per-flow: we surface a single sign-up call-to-action.
+	if !cfg.DryRun && anyClaimed {
 		if err := client.Available(); err != nil {
 			res.Onboarding = &Onboarding{Reason: OnboardCLIMissing, Message: err.Error()}
 		} else if !client.Authenticated() {
@@ -124,7 +135,7 @@ func Run(cfg Config) (*Result, error) {
 	// Resolve the build name to an app id once: `test create --app` needs it.
 	var appID string
 	var appIDErr error
-	if res.Onboarding == nil && !cfg.DryRun && cfg.BuildName != "" {
+	if res.Onboarding == nil && !cfg.DryRun && anyClaimed && cfg.BuildName != "" {
 		appID, appIDErr = client.AppID(cfg.BuildName)
 	}
 
@@ -247,9 +258,11 @@ func Run(cfg Config) (*Result, error) {
 			fr.Detail = "the flow could not run to completion on the cloud device: no steps executed (the app may have failed to launch, or the run aborted before the first step finished). See the report."
 		default:
 			// Report finalized as a failure with steps executed: a real flow break.
+			// Redact secret --var values (passwords/tokens) that were inlined into
+			// step text, so they don't leak into the terminal or JSON.
 			fr.Status = StatusFailed
-			fr.FailedStep = firstNonEmptyStr(report.FailedStep, run.FailedStep)
-			fr.FailedReason = report.FailedReason
+			fr.FailedStep = redactVars(firstNonEmptyStr(report.FailedStep, run.FailedStep), cfg.Vars)
+			fr.FailedReason = redactVars(report.FailedReason, cfg.Vars)
 			fr.ReportURL = reportURL
 			fr.Detail = staticPassedMessage(f, claims, fr.FailedStep)
 		}
@@ -283,6 +296,28 @@ func firstNonEmptyStr(vals ...string) string {
 		}
 	}
 	return ""
+}
+
+// redactVars replaces the values of sensitive --var entries (passwords, tokens,
+// secrets) wherever they appear in a reported string, so inlined credentials
+// don't leak into the terminal or JSON output.
+func redactVars(s string, vars map[string]string) string {
+	for k, v := range vars {
+		if v != "" && isSensitiveKey(k) {
+			s = strings.ReplaceAll(s, v, "[redacted]")
+		}
+	}
+	return s
+}
+
+func isSensitiveKey(k string) bool {
+	k = strings.ToLower(k)
+	for _, marker := range []string{"pass", "secret", "token", "key", "cred", "auth", "pin", "otp"} {
+		if strings.Contains(k, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 // testName builds a per-build Revyl test name so the same flow run against two

--- a/internal/verify/runner.go
+++ b/internal/verify/runner.go
@@ -212,8 +212,13 @@ func Run(cfg Config) (*Result, error) {
 		}
 
 		// Enrich with the execution report: the verdict is Revyl's, and the
-		// failing step + reason are the evidence.
+		// failing step + reason are the evidence. `revyl test run` can return a
+		// moment before the report finalizes, so poll briefly until it settles.
 		report, _ := client.Report(tname)
+		for tries := 0; !report.Decided && tries < 12; tries++ {
+			time.Sleep(3 * time.Second)
+			report, _ = client.Report(tname)
+		}
 		passed := run.Passed
 		if report.Decided {
 			passed = report.Passed

--- a/internal/verify/runner.go
+++ b/internal/verify/runner.go
@@ -121,10 +121,11 @@ func Run(cfg Config) (*Result, error) {
 		}
 	}
 
-	// Resolve the build name to an app id once — `test create --app` needs it.
+	// Resolve the build name to an app id once: `test create --app` needs it.
 	var appID string
+	var appIDErr error
 	if res.Onboarding == nil && !cfg.DryRun && cfg.BuildName != "" {
-		appID, _ = client.AppID(cfg.BuildName)
+		appID, appIDErr = client.AppID(cfg.BuildName)
 	}
 
 	for _, f := range AllFlows() {
@@ -174,7 +175,10 @@ func Run(cfg Config) (*Result, error) {
 		}
 		if appID == "" {
 			fr.Status = StatusError
-			fr.Detail = fmt.Sprintf("no Revyl app found matching build name %q — check `revyl app list`", cfg.BuildName)
+			fr.Detail = fmt.Sprintf("could not resolve a Revyl app for build name %q (check `revyl app list`)", cfg.BuildName)
+			if appIDErr != nil {
+				fr.Detail += ": " + appIDErr.Error()
+			}
 			res.Flows = append(res.Flows, fr)
 			continue
 		}
@@ -230,17 +234,24 @@ func Run(cfg Config) (*Result, error) {
 			fr.Status = StatusVerified
 			fr.Detail = "flow ran on-device and behaved correctly"
 		case report.Decided && report.StepsRun == 0:
-			// No step actually executed — a setup/launch failure, NOT a broken
+			// No step actually executed: a setup/launch failure, not a broken
 			// flow. Reporting it as a flow failure would be dishonest.
 			fr.Status = StatusError
 			fr.ReportURL = reportURL
-			fr.Detail = "the flow couldn't run to completion on the cloud device — no steps executed (the app may have failed to launch, or the run aborted before the first step finished). See the report."
-		default:
+			fr.Detail = "the flow could not run to completion on the cloud device: no steps executed (the app may have failed to launch, or the run aborted before the first step finished). See the report."
+		case report.Decided:
+			// Report finalized as a failure with steps executed: a real flow break.
 			fr.Status = StatusFailed
 			fr.FailedStep = firstNonEmptyStr(report.FailedStep, run.FailedStep)
 			fr.FailedReason = report.FailedReason
 			fr.ReportURL = reportURL
 			fr.Detail = staticPassedMessage(f, claims, fr.FailedStep)
+		default:
+			// The report never finalized, so a non-zero exit alone isn't enough to
+			// confirm a real flow failure. Don't cry wolf.
+			fr.Status = StatusError
+			fr.ReportURL = reportURL
+			fr.Detail = "could not determine the outcome: the Revyl report did not finalize. Rerun, or open the report."
 		}
 		res.Flows = append(res.Flows, fr)
 	}

--- a/internal/verify/runner.go
+++ b/internal/verify/runner.go
@@ -152,7 +152,7 @@ func Run(cfg Config) (*Result, error) {
 		// No usable Revyl account → pending behind sign-up (see res.Onboarding).
 		if res.Onboarding != nil {
 			fr.Status = StatusPending
-			fr.Detail = "sign up for Revyl to validate this flow on a real device"
+			fr.Detail = "sign up for Revyl to validate this flow on a cloud device"
 			res.Flows = append(res.Flows, fr)
 			continue
 		}
@@ -226,9 +226,9 @@ func Run(cfg Config) (*Result, error) {
 func staticPassedMessage(f Flow, c codescan.Claims, failedStep string) string {
 	var b strings.Builder
 	if f.StaticPassed(c) {
-		fmt.Fprintf(&b, "Static analysis PASSED §%s — it found `%s` in your source and suppressed the warning, but the flow failed on a real device", f.Guideline, f.AntiPattern)
+		fmt.Fprintf(&b, "Static analysis PASSED §%s — it found `%s` in your source and suppressed the warning, but the flow failed on a cloud device", f.Guideline, f.AntiPattern)
 	} else {
-		fmt.Fprintf(&b, "The §%s flow failed on a real device", f.Guideline)
+		fmt.Fprintf(&b, "The §%s flow failed on a cloud device", f.Guideline)
 	}
 	if failedStep != "" {
 		fmt.Fprintf(&b, " at %q", failedStep)

--- a/internal/verify/runner.go
+++ b/internal/verify/runner.go
@@ -196,22 +196,30 @@ func Run(cfg Config) (*Result, error) {
 			continue
 		}
 
-		// Enrich with the execution report: session_status is Revyl's
-		// authoritative verdict, and the failing step + reason are the evidence.
+		// Enrich with the execution report: the verdict is Revyl's, and the
+		// failing step + reason are the evidence.
 		report, _ := client.Report(f.TestName)
 		passed := run.Passed
 		if report.Decided {
 			passed = report.Passed
 		}
+		reportURL := firstNonEmptyStr(client.ReportShareURL(f.TestName), report.ReportURL)
 
-		if passed {
+		switch {
+		case passed:
 			fr.Status = StatusVerified
 			fr.Detail = "flow ran on-device and behaved correctly"
-		} else {
+		case report.Decided && report.StepsRun == 0:
+			// No step actually executed — a setup/launch failure, NOT a broken
+			// flow. Reporting it as a flow failure would be dishonest.
+			fr.Status = StatusError
+			fr.ReportURL = reportURL
+			fr.Detail = "the flow couldn't run to completion on the cloud device — no steps executed (the app may have failed to launch, or the run aborted before the first step finished). See the report."
+		default:
 			fr.Status = StatusFailed
 			fr.FailedStep = firstNonEmptyStr(report.FailedStep, run.FailedStep)
 			fr.FailedReason = report.FailedReason
-			fr.ReportURL = firstNonEmptyStr(client.ReportShareURL(f.TestName), report.ReportURL)
+			fr.ReportURL = reportURL
 			fr.Detail = staticPassedMessage(f, claims, fr.FailedStep)
 		}
 		res.Flows = append(res.Flows, fr)

--- a/internal/verify/runner.go
+++ b/internal/verify/runner.go
@@ -1,0 +1,247 @@
+package verify
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/RevylAI/greenlight/internal/codescan"
+	"github.com/RevylAI/greenlight/internal/revyl"
+)
+
+// Flow result statuses.
+const (
+	StatusVerified = "verified" // ran on-device and behaved correctly
+	StatusFailed   = "failed"   // ran on-device and the flow broke (the catch)
+	StatusSkipped  = "skipped"  // feature not claimed, or dry-run
+	StatusError    = "error"    // could not run (auth/build/device/setup)
+)
+
+// Config controls a verify run.
+type Config struct {
+	ProjectPath string
+	BuildName   string            // Revyl registered build/app name (YAML build.name)
+	Platform    string            // "ios" | "android"
+	Flows       []string          // filter by flow ID; empty = all claimed
+	Vars        map[string]string // test variables (email, password, …)
+	DeviceModel string
+	OSVersion   string
+	Build       bool
+	Timeout     time.Duration
+	DryRun      bool
+	RevylBin    string
+}
+
+// FlowResult is the per-flow outcome.
+type FlowResult struct {
+	Flow         Flow   `json:"-"`
+	ID           string `json:"id"`
+	Guideline    string `json:"guideline"`
+	Title        string `json:"title"`
+	Status       string `json:"status"`
+	StaticPassed bool   `json:"static_passed"`
+	FailedStep   string `json:"failed_step,omitempty"`
+	ReportURL    string `json:"report_url,omitempty"`
+	Detail       string `json:"detail,omitempty"`
+	TaskID       string `json:"task_id,omitempty"`
+	YAML         string `json:"-"`
+}
+
+// Summary aggregates flow outcomes.
+type Summary struct {
+	Total    int  `json:"total"` // flows that ran or attempted to run
+	Verified int  `json:"verified"`
+	Failed   int  `json:"failed"`
+	Errored  int  `json:"errored"`
+	Skipped  int  `json:"skipped"`
+	Passed   bool `json:"passed"` // true iff zero failed and zero errored
+}
+
+// Result is the full verify report.
+type Result struct {
+	ProjectPath string          `json:"project_path"`
+	BuildName   string          `json:"build_name,omitempty"`
+	Claims      codescan.Claims `json:"claims"`
+	Flows       []FlowResult    `json:"flows"`
+	Summary     Summary         `json:"summary"`
+	DryRun      bool            `json:"dry_run"`
+	Elapsed     time.Duration   `json:"-"`
+}
+
+// Run executes runtime flow validation: static pre-scan to learn what the app
+// claims, then hand each claimed flow to the Revyl CLI to run on a device.
+func Run(cfg Config) (*Result, error) {
+	claims, err := codescan.DetectClaims(cfg.ProjectPath)
+	if err != nil {
+		return nil, fmt.Errorf("static pre-scan failed: %w", err)
+	}
+
+	platform := cfg.Platform
+	if platform == "" {
+		platform = "ios"
+	}
+
+	res := &Result{
+		ProjectPath: cfg.ProjectPath,
+		BuildName:   cfg.BuildName,
+		Claims:      claims,
+		DryRun:      cfg.DryRun,
+	}
+
+	selected := selectedSet(cfg.Flows)
+	client := revyl.NewClient(cfg.RevylBin)
+
+	for _, f := range AllFlows() {
+		if len(selected) > 0 && !selected[f.ID] {
+			continue
+		}
+		fr := FlowResult{
+			Flow:         f,
+			ID:           f.ID,
+			Guideline:    f.Guideline,
+			Title:        f.Title,
+			StaticPassed: f.StaticPassed(claims),
+		}
+
+		if !f.Claimed(claims) {
+			fr.Status = StatusSkipped
+			fr.Detail = "feature not detected in source — nothing to verify"
+			res.Flows = append(res.Flows, fr)
+			continue
+		}
+
+		fr.YAML = renderTestYAML(f, platform, cfg.BuildName, cfg.Vars)
+
+		if cfg.DryRun {
+			fr.Status = StatusSkipped
+			fr.Detail = "dry-run — generated the test, did not execute on a device"
+			res.Flows = append(res.Flows, fr)
+			continue
+		}
+
+		if cfg.BuildName == "" {
+			fr.Status = StatusError
+			fr.Detail = "no --build-name provided; cannot map the test to a registered Revyl build"
+			res.Flows = append(res.Flows, fr)
+			continue
+		}
+		if err := client.Available(); err != nil {
+			fr.Status = StatusError
+			fr.Detail = err.Error()
+			res.Flows = append(res.Flows, fr)
+			continue
+		}
+
+		path, werr := writeTempYAML(f.TestName, fr.YAML)
+		if werr != nil {
+			fr.Status = StatusError
+			fr.Detail = "could not stage test file: " + werr.Error()
+			res.Flows = append(res.Flows, fr)
+			continue
+		}
+
+		if _, cerr := client.EnsureTest(path); cerr != nil {
+			fr.Status = StatusError
+			fr.Detail = cerr.Error()
+			cleanupTemp(path)
+			res.Flows = append(res.Flows, fr)
+			continue
+		}
+
+		run, rerr := client.RunTest(f.TestName, revyl.RunOpts{
+			DeviceModel: cfg.DeviceModel,
+			OSVersion:   cfg.OSVersion,
+			Build:       cfg.Build,
+			Timeout:     cfg.Timeout,
+		})
+		cleanupTemp(path)
+		fr.TaskID = run.TaskID
+
+		if rerr != nil {
+			fr.Status = StatusError
+			fr.Detail = rerr.Error()
+			res.Flows = append(res.Flows, fr)
+			continue
+		}
+
+		if run.Passed {
+			fr.Status = StatusVerified
+			fr.Detail = "flow ran on-device and behaved correctly"
+		} else {
+			fr.Status = StatusFailed
+			fr.FailedStep = run.FailedStep
+			fr.ReportURL = client.ReportShareURL(f.TestName)
+			fr.Detail = staticPassedMessage(f, claims, run.FailedStep)
+		}
+		res.Flows = append(res.Flows, fr)
+	}
+
+	res.Summary = summarize(res.Flows)
+	return res, nil
+}
+
+// staticPassedMessage frames the headline insight: static said ship it, runtime
+// proved otherwise.
+func staticPassedMessage(f Flow, c codescan.Claims, failedStep string) string {
+	var b strings.Builder
+	if f.StaticPassed(c) {
+		fmt.Fprintf(&b, "Static analysis PASSED §%s — it found `%s` in your source and suppressed the warning. ", f.Guideline, f.AntiPattern)
+	} else {
+		fmt.Fprintf(&b, "§%s ", f.Guideline)
+	}
+	b.WriteString("But the flow failed on a real device")
+	if failedStep != "" {
+		fmt.Fprintf(&b, " at: %q", failedStep)
+	}
+	b.WriteString(". Apple exercises this flow manually during review.")
+	return b.String()
+}
+
+func summarize(flows []FlowResult) Summary {
+	s := Summary{}
+	for _, f := range flows {
+		switch f.Status {
+		case StatusVerified:
+			s.Total++
+			s.Verified++
+		case StatusFailed:
+			s.Total++
+			s.Failed++
+		case StatusError:
+			s.Total++
+			s.Errored++
+		case StatusSkipped:
+			s.Skipped++
+		}
+	}
+	s.Passed = s.Failed == 0 && s.Errored == 0
+	return s
+}
+
+func selectedSet(ids []string) map[string]bool {
+	m := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		if id = strings.TrimSpace(id); id != "" {
+			m[id] = true
+		}
+	}
+	return m
+}
+
+func writeTempYAML(name, content string) (string, error) {
+	dir, err := os.MkdirTemp("", "greenlight-verify-")
+	if err != nil {
+		return "", err
+	}
+	path := filepath.Join(dir, name+".yaml")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+func cleanupTemp(path string) {
+	os.RemoveAll(filepath.Dir(path))
+}

--- a/internal/verify/runner.go
+++ b/internal/verify/runner.go
@@ -140,7 +140,10 @@ func Run(cfg Config) (*Result, error) {
 			continue
 		}
 
-		fr.YAML = renderTestYAML(f, platform, cfg.BuildName, cfg.Vars)
+		// Unique test name per build — a stable name gets silently rebound to
+		// the first app's build by `revyl test create --force`.
+		tname := testName(cfg.BuildName, f.ID)
+		fr.YAML = renderTestYAML(f, tname, platform, cfg.BuildName, cfg.Vars)
 
 		if cfg.DryRun {
 			fr.Status = StatusSkipped
@@ -164,7 +167,7 @@ func Run(cfg Config) (*Result, error) {
 			continue
 		}
 
-		path, werr := writeTempYAML(f.TestName, fr.YAML)
+		path, werr := writeTempYAML(tname, fr.YAML)
 		if werr != nil {
 			fr.Status = StatusError
 			fr.Detail = "could not stage test file: " + werr.Error()
@@ -180,7 +183,7 @@ func Run(cfg Config) (*Result, error) {
 			continue
 		}
 
-		run, rerr := client.RunTest(f.TestName, revyl.RunOpts{
+		run, rerr := client.RunTest(tname, revyl.RunOpts{
 			DeviceModel: cfg.DeviceModel,
 			OSVersion:   cfg.OSVersion,
 			Build:       cfg.Build,
@@ -198,12 +201,12 @@ func Run(cfg Config) (*Result, error) {
 
 		// Enrich with the execution report: the verdict is Revyl's, and the
 		// failing step + reason are the evidence.
-		report, _ := client.Report(f.TestName)
+		report, _ := client.Report(tname)
 		passed := run.Passed
 		if report.Decided {
 			passed = report.Passed
 		}
-		reportURL := firstNonEmptyStr(client.ReportShareURL(f.TestName), report.ReportURL)
+		reportURL := firstNonEmptyStr(client.ReportShareURL(tname), report.ReportURL)
 
 		switch {
 		case passed:
@@ -252,6 +255,33 @@ func firstNonEmptyStr(vals ...string) string {
 		}
 	}
 	return ""
+}
+
+// testName builds a per-build Revyl test name so the same flow run against two
+// different apps never collides (a shared name gets rebound to the first build).
+func testName(buildName, flowID string) string {
+	b := slug(buildName)
+	if b == "" {
+		return "greenlight-" + flowID
+	}
+	return "greenlight-" + b + "-" + flowID
+}
+
+// slug lowercases and reduces a string to [a-z0-9-] for use in a test name.
+func slug(s string) string {
+	var b strings.Builder
+	dash := false
+	for _, r := range strings.ToLower(s) {
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'):
+			b.WriteRune(r)
+			dash = false
+		case !dash && b.Len() > 0:
+			b.WriteByte('-')
+			dash = true
+		}
+	}
+	return strings.Trim(b.String(), "-")
 }
 
 func summarize(flows []FlowResult) Summary {

--- a/internal/verify/runner.go
+++ b/internal/verify/runner.go
@@ -223,35 +223,32 @@ func Run(cfg Config) (*Result, error) {
 			time.Sleep(3 * time.Second)
 			report, _ = client.Report(tname)
 		}
-		passed := run.Passed
-		if report.Decided {
-			passed = report.Passed
-		}
 		reportURL := firstNonEmptyStr(client.ReportShareURL(tname), report.ReportURL)
 
 		switch {
-		case passed:
+		case !report.Decided:
+			// The report never finalized: we can't confirm the outcome either way
+			// (a passing OR failing exit code alone is not authoritative). Don't
+			// claim VERIFIED or FAILED on an unknown report.
+			fr.Status = StatusError
+			fr.ReportURL = reportURL
+			fr.Detail = "could not determine the outcome: the Revyl report did not finalize. Rerun, or open the report."
+		case report.Passed:
 			fr.Status = StatusVerified
 			fr.Detail = "flow ran on-device and behaved correctly"
-		case report.Decided && report.StepsRun == 0:
+		case report.StepsRun == 0:
 			// No step actually executed: a setup/launch failure, not a broken
 			// flow. Reporting it as a flow failure would be dishonest.
 			fr.Status = StatusError
 			fr.ReportURL = reportURL
 			fr.Detail = "the flow could not run to completion on the cloud device: no steps executed (the app may have failed to launch, or the run aborted before the first step finished). See the report."
-		case report.Decided:
+		default:
 			// Report finalized as a failure with steps executed: a real flow break.
 			fr.Status = StatusFailed
 			fr.FailedStep = firstNonEmptyStr(report.FailedStep, run.FailedStep)
 			fr.FailedReason = report.FailedReason
 			fr.ReportURL = reportURL
 			fr.Detail = staticPassedMessage(f, claims, fr.FailedStep)
-		default:
-			// The report never finalized, so a non-zero exit alone isn't enough to
-			// confirm a real flow failure. Don't cry wolf.
-			fr.Status = StatusError
-			fr.ReportURL = reportURL
-			fr.Detail = "could not determine the outcome: the Revyl report did not finalize. Rerun, or open the report."
 		}
 		res.Flows = append(res.Flows, fr)
 	}

--- a/internal/verify/runner.go
+++ b/internal/verify/runner.go
@@ -43,6 +43,7 @@ type FlowResult struct {
 	Status       string `json:"status"`
 	StaticPassed bool   `json:"static_passed"`
 	FailedStep   string `json:"failed_step,omitempty"`
+	FailedReason string `json:"failed_reason,omitempty"`
 	ReportURL    string `json:"report_url,omitempty"`
 	Detail       string `json:"detail,omitempty"`
 	TaskID       string `json:"task_id,omitempty"`
@@ -166,14 +167,23 @@ func Run(cfg Config) (*Result, error) {
 			continue
 		}
 
-		if run.Passed {
+		// Enrich with the execution report: session_status is Revyl's
+		// authoritative verdict, and the failing step + reason are the evidence.
+		report, _ := client.Report(f.TestName)
+		passed := run.Passed
+		if report.Decided {
+			passed = report.Passed
+		}
+
+		if passed {
 			fr.Status = StatusVerified
 			fr.Detail = "flow ran on-device and behaved correctly"
 		} else {
 			fr.Status = StatusFailed
-			fr.FailedStep = run.FailedStep
-			fr.ReportURL = client.ReportShareURL(f.TestName)
-			fr.Detail = staticPassedMessage(f, claims, run.FailedStep)
+			fr.FailedStep = firstNonEmptyStr(report.FailedStep, run.FailedStep)
+			fr.FailedReason = report.FailedReason
+			fr.ReportURL = firstNonEmptyStr(client.ReportShareURL(f.TestName), report.ReportURL)
+			fr.Detail = staticPassedMessage(f, claims, fr.FailedStep)
 		}
 		res.Flows = append(res.Flows, fr)
 	}
@@ -187,16 +197,24 @@ func Run(cfg Config) (*Result, error) {
 func staticPassedMessage(f Flow, c codescan.Claims, failedStep string) string {
 	var b strings.Builder
 	if f.StaticPassed(c) {
-		fmt.Fprintf(&b, "Static analysis PASSED §%s — it found `%s` in your source and suppressed the warning. ", f.Guideline, f.AntiPattern)
+		fmt.Fprintf(&b, "Static analysis PASSED §%s — it found `%s` in your source and suppressed the warning, but the flow failed on a real device", f.Guideline, f.AntiPattern)
 	} else {
-		fmt.Fprintf(&b, "§%s ", f.Guideline)
+		fmt.Fprintf(&b, "The §%s flow failed on a real device", f.Guideline)
 	}
-	b.WriteString("But the flow failed on a real device")
 	if failedStep != "" {
-		fmt.Fprintf(&b, " at: %q", failedStep)
+		fmt.Fprintf(&b, " at %q", failedStep)
 	}
 	b.WriteString(". Apple exercises this flow manually during review.")
 	return b.String()
+}
+
+func firstNonEmptyStr(vals ...string) string {
+	for _, v := range vals {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
 }
 
 func summarize(flows []FlowResult) Summary {

--- a/internal/verify/runner.go
+++ b/internal/verify/runner.go
@@ -3,7 +3,9 @@ package verify
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -44,9 +46,18 @@ type Config struct {
 	DeviceModel string
 	OSVersion   string
 	Build       bool
+	Artifact    string // path to a prebuilt .app/.apk to upload to Revyl before running
 	Timeout     time.Duration
 	DryRun      bool
 	RevylBin    string
+	Open        bool // auto-open the live Revyl session in the browser
+}
+
+// UploadResult records the outcome of uploading a local build artifact to Revyl.
+type UploadResult struct {
+	Artifact string `json:"artifact"`
+	Status   string `json:"status"` // "uploaded" | "failed"
+	Detail   string `json:"detail,omitempty"`
 }
 
 // FlowResult is the per-flow outcome.
@@ -84,6 +95,7 @@ type Result struct {
 	Flows       []FlowResult    `json:"flows"`
 	Summary     Summary         `json:"summary"`
 	Onboarding  *Onboarding     `json:"onboarding,omitempty"`
+	Upload      *UploadResult   `json:"upload,omitempty"`
 	DryRun      bool            `json:"dry_run"`
 	Elapsed     time.Duration   `json:"-"`
 }
@@ -132,11 +144,19 @@ func Run(cfg Config) (*Result, error) {
 		}
 	}
 
-	// Resolve the build name to an app id once: `test create --app` needs it.
+	// If a prebuilt artifact was provided, upload it to Revyl first (registering
+	// the app if its build name is new), so the run installs that local build.
+	// Then resolve the build name to an app id once: `test create --app` needs it.
 	var appID string
 	var appIDErr error
-	if res.Onboarding == nil && !cfg.DryRun && anyClaimed && cfg.BuildName != "" {
-		appID, appIDErr = client.AppID(cfg.BuildName)
+	var uploadErr error
+	if res.Onboarding == nil && !cfg.DryRun && anyClaimed {
+		if cfg.Artifact != "" {
+			res.Upload, appID, uploadErr = uploadLocalBuild(client, cfg, platform)
+		}
+		if uploadErr == nil && appID == "" && cfg.BuildName != "" {
+			appID, appIDErr = client.AppID(cfg.BuildName)
+		}
 	}
 
 	for _, f := range AllFlows() {
@@ -180,6 +200,15 @@ func Run(cfg Config) (*Result, error) {
 			continue
 		}
 
+		// A requested local-build upload failed → can't run against it. Surface
+		// the real cause instead of a misleading "could not resolve app".
+		if uploadErr != nil {
+			fr.Status = StatusError
+			fr.Detail = "could not upload the local build to Revyl: " + uploadErr.Error()
+			res.Flows = append(res.Flows, fr)
+			continue
+		}
+
 		if cfg.BuildName == "" {
 			fr.Status = StatusError
 			fr.Detail = "no --build-name provided; cannot map the test to a registered Revyl build"
@@ -213,12 +242,12 @@ func Run(cfg Config) (*Result, error) {
 			continue
 		}
 
-		run, rerr := client.RunTest(tname, revyl.RunOpts{
+		run, rerr := runWithLiveLink(client, tname, revyl.RunOpts{
 			DeviceModel: cfg.DeviceModel,
 			OSVersion:   cfg.OSVersion,
 			Build:       cfg.Build,
 			Timeout:     cfg.Timeout,
-		})
+		}, cfg.Open)
 		cleanupTemp(path)
 		fr.TaskID = run.TaskID
 
@@ -290,6 +319,137 @@ func staticPassedMessage(f Flow, c codescan.Claims, failedStep string) string {
 	}
 	b.WriteString(". Apple exercises this flow manually during review.")
 	return b.String()
+}
+
+// ValidateArtifact checks that a build artifact is one Revyl can ingest: a
+// simulator .app bundle (iOS) or an .apk (Android). Revyl runs on cloud
+// simulators, so a signed device .ipa is the wrong artifact and is rejected
+// with guidance. It also cross-checks the artifact kind against the target
+// platform so a mismatch (e.g. --platform ios with an .apk) fails here, not
+// with a confusing error mid-upload. An empty path is valid (no upload).
+func ValidateArtifact(path, platform string) error {
+	if strings.TrimSpace(path) == "" {
+		return nil
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("artifact not found: %s", path)
+	}
+	ext := strings.ToLower(filepath.Ext(path))
+	switch ext {
+	case ".app":
+		if !info.IsDir() {
+			return fmt.Errorf("%s: a simulator .app must be an app-bundle directory", path)
+		}
+	case ".apk":
+		if info.IsDir() {
+			return fmt.Errorf("%s: an .apk must be a file", path)
+		}
+	case ".ipa":
+		return fmt.Errorf("Revyl runs on cloud simulators and cannot ingest a device .ipa — build a simulator .app (iOS) or use an .apk (Android): %s", path)
+	default:
+		return fmt.Errorf("unsupported artifact %q — Revyl accepts a simulator .app (iOS) or an .apk (Android)", path)
+	}
+	switch strings.ToLower(strings.TrimSpace(platform)) {
+	case "ios":
+		if ext == ".apk" {
+			return fmt.Errorf("platform is iOS but the artifact is an Android .apk: %s", path)
+		}
+	case "android":
+		if ext == ".app" {
+			return fmt.Errorf("platform is Android but the artifact is an iOS .app: %s", path)
+		}
+	}
+	return nil
+}
+
+// uploadLocalBuild uploads cfg.Artifact to Revyl and returns the upload outcome
+// plus the resolved app id. If the build name already resolves the artifact is
+// uploaded to that app; otherwise a new app is registered first (an explicit,
+// headless step) and the artifact is uploaded to it.
+func uploadLocalBuild(client *revyl.Client, cfg Config, platform string) (*UploadResult, string, error) {
+	ur := &UploadResult{Artifact: cfg.Artifact, Status: "failed"}
+	if err := ValidateArtifact(cfg.Artifact, platform); err != nil {
+		ur.Detail = err.Error()
+		return ur, "", err
+	}
+	if cfg.BuildName == "" {
+		err := fmt.Errorf("--artifact needs --build-name to name or match the Revyl app for the uploaded build")
+		ur.Detail = err.Error()
+		return ur, "", err
+	}
+	// Resolve the app id: use the existing app if the build name resolves, else
+	// register a new app explicitly so `build upload` never needs a TTY.
+	appID, _ := client.AppID(cfg.BuildName)
+	if appID == "" {
+		id, err := client.CreateApp(cfg.BuildName, platform)
+		if err != nil {
+			ur.Detail = err.Error()
+			return ur, "", err
+		}
+		appID = id
+	}
+	fmt.Fprintf(os.Stderr, "  Uploading local build %s → Revyl…\n", filepath.Base(cfg.Artifact))
+	if _, err := client.UploadBuild(cfg.Artifact, appID); err != nil {
+		ur.Detail = err.Error()
+		return ur, appID, err
+	}
+	ur.Status = "uploaded"
+	return ur, appID, nil
+}
+
+// runWithLiveLink runs the test and, while it runs, prints the live Revyl
+// session link to stderr (so you can click it to watch the agent drive the
+// device); with open=true it also auto-opens the link in the browser. stderr
+// keeps --format json on stdout clean.
+func runWithLiveLink(client *revyl.Client, name string, opts revyl.RunOpts, open bool) (revyl.RunResult, error) {
+	type outcome struct {
+		run revyl.RunResult
+		err error
+	}
+	ch := make(chan outcome, 1)
+	go func() {
+		r, e := client.RunTest(name, opts)
+		ch <- outcome{r, e}
+	}()
+
+	stop := make(chan struct{})
+	go func() {
+		t := time.NewTicker(2 * time.Second)
+		defer t.Stop()
+		for {
+			select {
+			case <-stop:
+				return
+			case <-t.C:
+				if url := client.SessionURL(name); url != "" {
+					fmt.Fprintf(os.Stderr, "  Watch live: %s\n", url)
+					if open {
+						openBrowser(url)
+					}
+					return
+				}
+			}
+		}
+	}()
+
+	o := <-ch
+	close(stop)
+	return o.run, o.err
+}
+
+// openBrowser opens a URL in the default browser (best-effort, non-blocking).
+func openBrowser(url string) {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", url)
+	case "windows":
+		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
+	default:
+		cmd = exec.Command("xdg-open", url)
+	}
+	_ = cmd.Start()
 }
 
 func firstNonEmptyStr(vals ...string) string {

--- a/internal/verify/runner_test.go
+++ b/internal/verify/runner_test.go
@@ -1,0 +1,31 @@
+package verify
+
+import (
+	"strings"
+	"testing"
+)
+
+// redactVars must scrub sensitive --var values (passwords/tokens) from reported
+// strings while leaving non-sensitive ones (email) intact.
+func TestRedactVars(t *testing.T) {
+	vars := map[string]string{
+		"email":    "qa@acme.com",
+		"password": "hunter2",
+		"apiToken": "tok_abc123",
+	}
+	in := "Log in with qa@acme.com and hunter2 (token tok_abc123) failed"
+	got := redactVars(in, vars)
+
+	if strings.Contains(got, "hunter2") {
+		t.Errorf("password leaked: %q", got)
+	}
+	if strings.Contains(got, "tok_abc123") {
+		t.Errorf("token leaked: %q", got)
+	}
+	if !strings.Contains(got, "qa@acme.com") {
+		t.Errorf("non-sensitive email should remain: %q", got)
+	}
+	if !strings.Contains(got, "[redacted]") {
+		t.Errorf("expected a redaction marker: %q", got)
+	}
+}

--- a/internal/verify/runner_test.go
+++ b/internal/verify/runner_test.go
@@ -1,6 +1,8 @@
 package verify
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -27,5 +29,61 @@ func TestRedactVars(t *testing.T) {
 	}
 	if !strings.Contains(got, "[redacted]") {
 		t.Errorf("expected a redaction marker: %q", got)
+	}
+}
+
+// ValidateArtifact must accept a simulator .app (directory) and an .apk (file),
+// reject a device .ipa with simulator guidance, and reject other/missing paths.
+func TestValidateArtifact(t *testing.T) {
+	dir := t.TempDir()
+
+	appBundle := filepath.Join(dir, "Demo.app") // .app is a directory bundle
+	if err := os.Mkdir(appBundle, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	apk := filepath.Join(dir, "demo.apk") // .apk is a file
+	if err := os.WriteFile(apk, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ipa := filepath.Join(dir, "demo.ipa")
+	if err := os.WriteFile(ipa, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	appAsFile := filepath.Join(dir, "Bad.app") // .app that is wrongly a file
+	if err := os.WriteFile(appAsFile, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	zip := filepath.Join(dir, "demo.zip") // exists, but unsupported extension
+	if err := os.WriteFile(zip, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ValidateArtifact("", "ios"); err != nil {
+		t.Errorf("empty path should be valid (no upload requested): %v", err)
+	}
+	if err := ValidateArtifact(appBundle, "ios"); err != nil {
+		t.Errorf("a .app directory should be valid for ios: %v", err)
+	}
+	if err := ValidateArtifact(apk, "android"); err != nil {
+		t.Errorf("an .apk file should be valid for android: %v", err)
+	}
+	if err := ValidateArtifact(ipa, "ios"); err == nil || !strings.Contains(err.Error(), "simulator") {
+		t.Errorf("a .ipa should be rejected with simulator guidance, got: %v", err)
+	}
+	if err := ValidateArtifact(appAsFile, "ios"); err == nil {
+		t.Errorf("a .app that is a plain file should be rejected")
+	}
+	if err := ValidateArtifact(filepath.Join(dir, "nope.app"), "ios"); err == nil {
+		t.Errorf("a missing artifact should be rejected")
+	}
+	if err := ValidateArtifact(zip, "ios"); err == nil {
+		t.Errorf("an unsupported extension should be rejected")
+	}
+	// Platform/extension mismatches must be caught early, not mid-upload.
+	if err := ValidateArtifact(apk, "ios"); err == nil {
+		t.Errorf("an .apk on platform ios should be rejected")
+	}
+	if err := ValidateArtifact(appBundle, "android"); err == nil {
+		t.Errorf("a .app on platform android should be rejected")
 	}
 }


### PR DESCRIPTION
## What

Adds a runtime tier to greenlight. `greenlight verify` validates flow-dependent App Store guidelines on a Revyl cloud device, catching broken user flows that static analysis structurally can't.

Static analysis can confirm a flow exists in source. It can't confirm it works. A "Delete Account" button wired to nothing passes `codescan` (the string `deleteAccount` is present, so §5.1.1 is suppressed) but dead-ends at runtime, and Apple rejects it. `verify` runs the actual flow on a device and catches it. This is the runtime validation connecting greenlight to the Revyl CLI.

## How it works

1. A static pre-scan detects which flow-dependent features the app claims: account creation, in-app purchases, social login.
2. For each claimed flow, greenlight generates a Revyl test and hands it to the `revyl` CLI to run on a cloud device.
3. A flow that passes static analysis but fails on-device becomes a `BLOCK` static could never produce, with the failing step, the reason, and a shareable report link as evidence.

Flows covered: account-deletion (§5.1.1), restore-purchases (§3.1.1), sign-in-apple (§4.8).

```
greenlight verify . --build-name "My App" --var email=qa@acme.com --var password=secret
greenlight verify . --dry-run          # show the generated tests, no device
```

## A separate, opt-in tier

The static scanner is unchanged: offline, zero-account, instant. `verify` is a deliberately separate opt-in tier that needs the `revyl` CLI, a Revyl account, and a registered build. Run `preflight` for the free static checks, and reach for `verify` when you want to confirm the flows actually work. `preflight --verify` chains both in one command, and a sign-up call-to-action guides users who don't have Revyl yet. The static path never forces it.

## Also: codescan false-positive cleanup

Independent quality fixes surfaced while testing on a real SwiftUI app (27 warnings became a correct GREENLIT):

- §2.1 placeholder rule no longer fires on SwiftUI's `placeholder:` parameter and ordinary input hints. It was turning normal apps into dozens of warnings.
- §5.1.1 recognizes "Close account" and "cancel account" as account deletion, not only "delete account", so apps that do offer deletion aren't false-warned. It deliberately excludes "deactivate", which Apple deems insufficient.
- "Missing safeguard" rules report once per file instead of once per matching line.

## Validation

Validated end to end against a real cloud-sim run. greenlight drives sign-up, then Settings, then Close account, then confirm, and correctly reports the flow dead-ending on the confirmation screen instead of returning the user to a logged-out state. Build, `go vet`, and tests are green, including new tests for the report parser, the setup vs. flow-failure classification, and the codescan rule changes.

## Files

- `internal/verify/`: flow registry, Revyl test YAML generation, the runner
- `internal/revyl/`: thin wrapper over the `revyl` CLI (create/run/report, app-id resolution)
- `internal/codescan/claims.go`: feature detection for the runtime tier. Rule fixes in `rules.go`
- `internal/cli/verify.go` and `preflight.go`: the command and the opt-in chain
- `README.md`, `SKILL.md`: documentation
