### PR TITLE
Tier 1: QOL + CI hygiene (version, UTF-8 lengths, inline ignore, gofmt gate)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 jobs:
-  build:
+  format:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -16,11 +16,32 @@ jobs:
         with:
           go-version: "1.24"
 
-      - name: Build
-        run: go build ./...
+      - name: gofmt
+        run: |
+          unformatted=$(gofmt -l .)
+          if [ -n "$unformatted" ]; then
+            echo "These files are not gofmt-formatted (run: gofmt -w .):"
+            echo "$unformatted"
+            exit 1
+          fi
+
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
 
       - name: Vet
         run: go vet ./...
 
+      - name: Build
+        run: go build ./...
+
       - name: Test
-        run: go test ./...
+        run: go test -race ./...

--- a/internal/asc/apps.go
+++ b/internal/asc/apps.go
@@ -9,10 +9,10 @@ type App struct {
 }
 
 type AppAttributes struct {
-	Name             string `json:"name"`
-	BundleID         string `json:"bundleId"`
-	SKU              string `json:"sku"`
-	PrimaryLocale    string `json:"primaryLocale"`
+	Name                     string `json:"name"`
+	BundleID                 string `json:"bundleId"`
+	SKU                      string `json:"sku"`
+	PrimaryLocale            string `json:"primaryLocale"`
 	ContentRightsDeclaration string `json:"contentRightsDeclaration"`
 }
 
@@ -23,10 +23,10 @@ type AppInfo struct {
 }
 
 type AppInfoAttributes struct {
-	AppStoreState    string `json:"appStoreState"`
+	AppStoreState     string `json:"appStoreState"`
 	AppStoreAgeRating string `json:"appStoreAgeRating"`
-	BrazilAgeRating  string `json:"brazilAgeRating"`
-	KidsAgeBand      string `json:"kidsAgeBand"`
+	BrazilAgeRating   string `json:"brazilAgeRating"`
+	KidsAgeBand       string `json:"kidsAgeBand"`
 }
 
 // AppStoreVersion represents a version of an app.
@@ -50,12 +50,12 @@ type VersionLocalization struct {
 }
 
 type VersionLocalizationAttributes struct {
-	Locale       string `json:"locale"`
-	Description  string `json:"description"`
-	Keywords     string `json:"keywords"`
-	WhatsNew     string `json:"whatsNew"`
-	SupportURL   string `json:"supportUrl"`
-	MarketingURL string `json:"marketingUrl"`
+	Locale          string `json:"locale"`
+	Description     string `json:"description"`
+	Keywords        string `json:"keywords"`
+	WhatsNew        string `json:"whatsNew"`
+	SupportURL      string `json:"supportUrl"`
+	MarketingURL    string `json:"marketingUrl"`
 	PromotionalText string `json:"promotionalText"`
 }
 
@@ -66,11 +66,11 @@ type Build struct {
 }
 
 type BuildAttributes struct {
-	Version              string `json:"version"`
-	UploadedDate         string `json:"uploadedDate"`
-	ProcessingState      string `json:"processingState"`
-	MinOsVersion         string `json:"minOsVersion"`
-	UsesNonExemptEncryption *bool `json:"usesNonExemptEncryption"`
+	Version                 string `json:"version"`
+	UploadedDate            string `json:"uploadedDate"`
+	ProcessingState         string `json:"processingState"`
+	MinOsVersion            string `json:"minOsVersion"`
+	UsesNonExemptEncryption *bool  `json:"usesNonExemptEncryption"`
 }
 
 // ScreenshotSet represents a set of screenshots for a device type.
@@ -155,10 +155,10 @@ type Screenshot struct {
 }
 
 type ScreenshotAttributes struct {
-	FileSize      int    `json:"fileSize"`
-	FileName      string `json:"fileName"`
-	ImageAsset    *ImageAsset `json:"imageAsset"`
-	AssetToken    string `json:"assetToken"`
+	FileSize         int         `json:"fileSize"`
+	FileName         string      `json:"fileName"`
+	ImageAsset       *ImageAsset `json:"imageAsset"`
+	AssetToken       string      `json:"assetToken"`
 	UploadOperations interface{} `json:"uploadOperations"`
 }
 
@@ -183,11 +183,11 @@ type BetaGroup struct {
 }
 
 type BetaGroupAttributes struct {
-	Name                      string `json:"name"`
-	IsInternalGroup           bool   `json:"isInternalGroup"`
-	PublicLinkEnabled         *bool  `json:"publicLinkEnabled"`
-	PublicLinkLimitEnabled    *bool  `json:"publicLinkLimitEnabled"`
-	HasAccessToAllBuilds      *bool  `json:"hasAccessToAllBuilds"`
+	Name                   string `json:"name"`
+	IsInternalGroup        bool   `json:"isInternalGroup"`
+	PublicLinkEnabled      *bool  `json:"publicLinkEnabled"`
+	PublicLinkLimitEnabled *bool  `json:"publicLinkLimitEnabled"`
+	HasAccessToAllBuilds   *bool  `json:"hasAccessToAllBuilds"`
 }
 
 // GetBetaGroups fetches TestFlight beta groups for an app.
@@ -206,8 +206,8 @@ type AppPrice struct {
 }
 
 type AppPriceAttributes struct {
-	Manual      bool   `json:"manual"`
-	StartDate   string `json:"startDate"`
+	Manual    bool   `json:"manual"`
+	StartDate string `json:"startDate"`
 }
 
 // Territory represents an App Store territory.
@@ -231,8 +231,8 @@ func (c *Client) GetAppAvailability(appID string) ([]Territory, error) {
 
 // AppPricePoint represents a price tier.
 type AppPricePoint struct {
-	ID         string                   `json:"id"`
-	Attributes AppPricePointAttributes  `json:"attributes"`
+	ID         string                  `json:"id"`
+	Attributes AppPricePointAttributes `json:"attributes"`
 }
 
 type AppPricePointAttributes struct {

--- a/internal/asc/session_auth.go
+++ b/internal/asc/session_auth.go
@@ -12,20 +12,20 @@ import (
 )
 
 const (
-	appleAuthURL = "https://idmsa.apple.com/appleauth/auth"
+	appleAuthURL  = "https://idmsa.apple.com/appleauth/auth"
 	ascSessionURL = "https://appstoreconnect.apple.com/olympus/v1/session"
 )
 
 // Session holds Apple ID session state for authenticated requests.
 type Session struct {
-	AppleID     string            `json:"apple_id"`
-	SessionID   string            `json:"session_id"`
-	Scnt        string            `json:"scnt"`
-	Cookies     []*SerializedCookie `json:"cookies"`
-	TeamID      string            `json:"team_id,omitempty"`
-	ProviderID  string            `json:"provider_id,omitempty"`
-	ExpiresAt   time.Time         `json:"expires_at"`
-	httpClient  *http.Client
+	AppleID    string              `json:"apple_id"`
+	SessionID  string              `json:"session_id"`
+	Scnt       string              `json:"scnt"`
+	Cookies    []*SerializedCookie `json:"cookies"`
+	TeamID     string              `json:"team_id,omitempty"`
+	ProviderID string              `json:"provider_id,omitempty"`
+	ExpiresAt  time.Time           `json:"expires_at"`
+	httpClient *http.Client
 }
 
 // SerializedCookie is a JSON-safe cookie representation.
@@ -63,9 +63,9 @@ type SessionInfo struct {
 		Email    string `json:"emailAddress"`
 	} `json:"user"`
 	Provider struct {
-		ProviderID   int    `json:"providerId"`
-		Name         string `json:"name"`
-		PublicKeyID  string `json:"publicKeyId"`
+		ProviderID  int    `json:"providerId"`
+		Name        string `json:"name"`
+		PublicKeyID string `json:"publicKeyId"`
 	} `json:"provider"`
 	AvailableProviders []struct {
 		ProviderID int    `json:"providerId"`
@@ -76,11 +76,11 @@ type SessionInfo struct {
 // commonHeaders returns the headers Apple expects for auth requests.
 func commonHeaders() map[string]string {
 	return map[string]string{
-		"Content-Type":           "application/json",
-		"Accept":                 "application/json",
-		"X-Requested-With":      "XMLHttpRequest",
-		"X-Apple-Widget-Key":    "e0b80c3bf78523bfe80571b6ff2e766c", // Public widget key used by ASC web
-		"User-Agent":            "greenlight/1.0",
+		"Content-Type":       "application/json",
+		"Accept":             "application/json",
+		"X-Requested-With":   "XMLHttpRequest",
+		"X-Apple-Widget-Key": "e0b80c3bf78523bfe80571b6ff2e766c", // Public widget key used by ASC web
+		"User-Agent":         "greenlight/1.0",
 	}
 }
 

--- a/internal/checks/tier1_metadata.go
+++ b/internal/checks/tier1_metadata.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/RevylAI/greenlight/internal/asc"
 )
@@ -119,12 +120,12 @@ func checkMetadataCompleteness(ctx context.Context, client *asc.Client, appID st
 				Detail:    "A description is required for App Store submission.",
 				Fix:       "Add a description in App Store Connect → Version Information.",
 			})
-		} else if len(desc) > maxDescriptionLength {
+		} else if utf8.RuneCountInString(desc) > maxDescriptionLength {
 			*findings = append(*findings, Finding{
 				Tier:      TierMetadata,
 				Severity:  SeverityBlock,
 				Guideline: "2.3",
-				Title:     fmt.Sprintf("[%s] Description exceeds %d character limit (%d chars)", locale, maxDescriptionLength, len(desc)),
+				Title:     fmt.Sprintf("[%s] Description exceeds %d character limit (%d chars)", locale, maxDescriptionLength, utf8.RuneCountInString(desc)),
 				Detail:    "App Store Connect enforces a maximum description length.",
 				Fix:       fmt.Sprintf("Shorten your description to %d characters or less.", maxDescriptionLength),
 			})
@@ -141,12 +142,12 @@ func checkMetadataCompleteness(ctx context.Context, client *asc.Client, appID st
 				Detail:    "Keywords help users discover your app and are recommended.",
 				Fix:       "Add relevant keywords separated by commas.",
 			})
-		} else if len(kw) > maxKeywordsLength {
+		} else if utf8.RuneCountInString(kw) > maxKeywordsLength {
 			*findings = append(*findings, Finding{
 				Tier:      TierMetadata,
 				Severity:  SeverityBlock,
 				Guideline: "2.3",
-				Title:     fmt.Sprintf("[%s] Keywords exceed %d character limit (%d chars)", locale, maxKeywordsLength, len(kw)),
+				Title:     fmt.Sprintf("[%s] Keywords exceed %d character limit (%d chars)", locale, maxKeywordsLength, utf8.RuneCountInString(kw)),
 				Detail:    "Keywords field has a strict 100-character limit including commas and spaces.",
 				Fix:       "Shorten your keywords to 100 characters. Remove less important terms or use shorter synonyms.",
 			})
@@ -166,12 +167,12 @@ func checkMetadataCompleteness(ctx context.Context, client *asc.Client, appID st
 
 		// Promotional text: length limit
 		pt := strings.TrimSpace(attrs.PromotionalText)
-		if pt != "" && len(pt) > maxPromotionalTextLength {
+		if pt != "" && utf8.RuneCountInString(pt) > maxPromotionalTextLength {
 			*findings = append(*findings, Finding{
 				Tier:      TierMetadata,
 				Severity:  SeverityBlock,
 				Guideline: "2.3",
-				Title:     fmt.Sprintf("[%s] Promotional text exceeds %d character limit (%d chars)", locale, maxPromotionalTextLength, len(pt)),
+				Title:     fmt.Sprintf("[%s] Promotional text exceeds %d character limit (%d chars)", locale, maxPromotionalTextLength, utf8.RuneCountInString(pt)),
 				Detail:    "Promotional text has a 170-character limit.",
 				Fix:       fmt.Sprintf("Shorten your promotional text to %d characters.", maxPromotionalTextLength),
 			})
@@ -496,12 +497,12 @@ func checkAppNameLength(ctx context.Context, client *asc.Client, appID string, f
 	}
 
 	name := strings.TrimSpace(app.Attributes.Name)
-	if len(name) > maxAppNameLength {
+	if utf8.RuneCountInString(name) > maxAppNameLength {
 		*findings = append(*findings, Finding{
 			Tier:      TierMetadata,
 			Severity:  SeverityBlock,
 			Guideline: "2.3",
-			Title:     fmt.Sprintf("App name exceeds %d character limit (%d chars)", maxAppNameLength, len(name)),
+			Title:     fmt.Sprintf("App name exceeds %d character limit (%d chars)", maxAppNameLength, utf8.RuneCountInString(name)),
 			Detail:    "App Store app names are limited to 30 characters.",
 			Fix:       fmt.Sprintf("Shorten your app name to %d characters or less.", maxAppNameLength),
 		})

--- a/internal/checks/tier1_metadata.go
+++ b/internal/checks/tier1_metadata.go
@@ -345,9 +345,9 @@ var requiredScreenshotDimensions = map[string]struct {
 	width  int
 	height int
 }{
-	"APP_IPHONE_67":  {"iPhone 6.7\"", 1290, 2796},
-	"APP_IPHONE_65":  {"iPhone 6.5\"", 1284, 2778},
-	"APP_IPHONE_55":  {"iPhone 5.5\"", 1242, 2208},
+	"APP_IPHONE_67":         {"iPhone 6.7\"", 1290, 2796},
+	"APP_IPHONE_65":         {"iPhone 6.5\"", 1284, 2778},
+	"APP_IPHONE_55":         {"iPhone 5.5\"", 1242, 2208},
 	"APP_IPAD_PRO_3GEN_129": {"iPad Pro 12.9\"", 2048, 2732},
 	"APP_IPAD_PRO_129":      {"iPad Pro 12.9\" (2nd gen)", 2048, 2732},
 }
@@ -448,19 +448,19 @@ func checkTerritoryAvailability(ctx context.Context, client *asc.Client, appID s
 
 	if len(territories) == 0 {
 		*findings = append(*findings, Finding{
-			Tier:      TierMetadata,
-			Severity:  SeverityBlock,
-			Title:     "App not available in any territory",
-			Detail:    "The app has no territory availability configured.",
-			Fix:       "Set territory availability in App Store Connect → Pricing and Availability.",
+			Tier:     TierMetadata,
+			Severity: SeverityBlock,
+			Title:    "App not available in any territory",
+			Detail:   "The app has no territory availability configured.",
+			Fix:      "Set territory availability in App Store Connect → Pricing and Availability.",
 		})
 	} else if len(territories) < 5 {
 		*findings = append(*findings, Finding{
-			Tier:      TierMetadata,
-			Severity:  SeverityInfo,
-			Title:     fmt.Sprintf("App available in only %d territories", len(territories)),
-			Detail:    "Your app is available in very few territories. Consider expanding for wider reach.",
-			Fix:       "Review territory availability in App Store Connect → Pricing and Availability.",
+			Tier:     TierMetadata,
+			Severity: SeverityInfo,
+			Title:    fmt.Sprintf("App available in only %d territories", len(territories)),
+			Detail:   "Your app is available in very few territories. Consider expanding for wider reach.",
+			Fix:      "Review territory availability in App Store Connect → Pricing and Availability.",
 		})
 	}
 
@@ -478,11 +478,11 @@ func checkPricingConsistency(ctx context.Context, client *asc.Client, appID stri
 
 	if len(prices) == 0 {
 		*findings = append(*findings, Finding{
-			Tier:      TierMetadata,
-			Severity:  SeverityWarn,
-			Title:     "No price schedule configured",
-			Detail:    "No pricing information found. Ensure your app's price (including Free) is explicitly set.",
-			Fix:       "Set pricing in App Store Connect → Pricing and Availability.",
+			Tier:     TierMetadata,
+			Severity: SeverityWarn,
+			Title:    "No price schedule configured",
+			Detail:   "No pricing information found. Ensure your app's price (including Free) is explicitly set.",
+			Fix:      "Set pricing in App Store Connect → Pricing and Availability.",
 		})
 	}
 

--- a/internal/checks/tier2_content.go
+++ b/internal/checks/tier2_content.go
@@ -55,9 +55,9 @@ func checkPlatformReferences(ctx context.Context, client *asc.Client, appID stri
 	for _, loc := range localizations {
 		locale := loc.Attributes.Locale
 		fields := map[string]string{
-			"description":     loc.Attributes.Description,
-			"keywords":        loc.Attributes.Keywords,
-			"what's new":      loc.Attributes.WhatsNew,
+			"description":      loc.Attributes.Description,
+			"keywords":         loc.Attributes.Keywords,
+			"what's new":       loc.Attributes.WhatsNew,
 			"promotional text": loc.Attributes.PromotionalText,
 		}
 
@@ -96,9 +96,9 @@ func checkPlaceholderContent(ctx context.Context, client *asc.Client, appID stri
 	for _, loc := range localizations {
 		locale := loc.Attributes.Locale
 		fields := map[string]string{
-			"description":     loc.Attributes.Description,
-			"keywords":        loc.Attributes.Keywords,
-			"what's new":      loc.Attributes.WhatsNew,
+			"description":      loc.Attributes.Description,
+			"keywords":         loc.Attributes.Keywords,
+			"what's new":       loc.Attributes.WhatsNew,
 			"promotional text": loc.Attributes.PromotionalText,
 		}
 

--- a/internal/checks/types.go
+++ b/internal/checks/types.go
@@ -4,9 +4,9 @@ package checks
 type Severity int
 
 const (
-	SeverityInfo Severity = iota // Best practice recommendation
-	SeverityWarn                 // High risk of rejection
-	SeverityBlock                // Will almost certainly be rejected
+	SeverityInfo  Severity = iota // Best practice recommendation
+	SeverityWarn                  // High risk of rejection
+	SeverityBlock                 // Will almost certainly be rejected
 )
 
 func (s Severity) String() string {
@@ -52,10 +52,10 @@ type Results struct {
 
 // Summary provides aggregate counts.
 type Summary struct {
-	Total  int `json:"total"`
-	Blocks int `json:"blocks"`
-	Warns  int `json:"warns"`
-	Infos  int `json:"infos"`
+	Total  int  `json:"total"`
+	Blocks int  `json:"blocks"`
+	Warns  int  `json:"warns"`
+	Infos  int  `json:"infos"`
 	Passed bool `json:"passed"` // true if zero BLOCKs
 }
 

--- a/internal/cli/codescan.go
+++ b/internal/cli/codescan.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/fatih/color"
 	"github.com/RevylAI/greenlight/internal/codescan"
+	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cli/guidelines.go
+++ b/internal/cli/guidelines.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/fatih/color"
 	"github.com/RevylAI/greenlight/internal/guidelines"
+	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cli/ipa.go
+++ b/internal/cli/ipa.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/fatih/color"
 	"github.com/RevylAI/greenlight/internal/ipa"
+	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cli/privacy.go
+++ b/internal/cli/privacy.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/fatih/color"
 	"github.com/RevylAI/greenlight/internal/privacy"
+	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -33,6 +33,8 @@ Get started:
 
 func SetVersion(v string) {
 	appVersion = v
+	// Enables `greenlight --version` (cobra auto-adds the flag when set).
+	rootCmd.Version = resolveVersion()
 }
 
 func Execute() error {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -43,6 +43,8 @@ func Execute() error {
 
 func init() {
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "verbose output")
+	// Match the `version` subcommand's wording ("greenlight <v>") for `--version`.
+	rootCmd.SetVersionTemplate("greenlight {{.Version}}\n")
 
 	rootCmd.AddCommand(scanCmd)
 	rootCmd.AddCommand(authCmd)

--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"runtime/debug"
 
 	"github.com/spf13/cobra"
 )
@@ -10,6 +11,24 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print the greenlight version",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("greenlight %s\n", appVersion)
+		fmt.Printf("greenlight %s\n", resolveVersion())
 	},
+}
+
+// resolveVersion prefers the ldflags-injected version (release builds), then
+// falls back to the module version embedded by the Go toolchain so that
+// `go install ...@latest` / `@v1.2.3` reports a real version instead of "dev".
+func resolveVersion() string {
+	if appVersion != "" && appVersion != "dev" {
+		return appVersion
+	}
+	if info, ok := debug.ReadBuildInfo(); ok {
+		if v := info.Main.Version; v != "" && v != "(devel)" {
+			return v
+		}
+	}
+	if appVersion != "" {
+		return appVersion
+	}
+	return "dev"
 }

--- a/internal/cli/version_test.go
+++ b/internal/cli/version_test.go
@@ -1,0 +1,28 @@
+package cli
+
+import "testing"
+
+// An ldflags-injected version always wins over the build-info fallback.
+func TestResolveVersionPrefersInjected(t *testing.T) {
+	old := appVersion
+	defer func() { appVersion = old }()
+
+	appVersion = "v1.2.3"
+	if got := resolveVersion(); got != "v1.2.3" {
+		t.Errorf("resolveVersion() = %q, want v1.2.3", got)
+	}
+}
+
+// With no injected version, resolveVersion falls back to build info (or "dev")
+// but must never return an empty string.
+func TestResolveVersionNeverEmpty(t *testing.T) {
+	old := appVersion
+	defer func() { appVersion = old }()
+
+	for _, v := range []string{"", "dev"} {
+		appVersion = v
+		if got := resolveVersion(); got == "" {
+			t.Errorf("resolveVersion() with appVersion=%q returned empty", v)
+		}
+	}
+}

--- a/internal/codescan/rules.go
+++ b/internal/codescan/rules.go
@@ -385,6 +385,12 @@ func suppressedByIgnore(lines []string, lineNum int, ruleID string) bool {
 	return lineNum > 0 && directiveSuppresses(lines[lineNum-1], ruleID)
 }
 
+// directiveSuppresses reports whether line carries a directive suppressing
+// ruleID. The marker is matched as a plain substring (no comment/string parsing).
+// A directive with no trailing tokens is "bare" and suppresses every rule;
+// otherwise each whitespace/comma-separated token is matched against ruleID, so
+// `greenlight:ignore <id> <reason>` works but `greenlight:ignore <reason>` (no
+// id) does NOT blanket-suppress — use a bare directive for that.
 func directiveSuppresses(line, ruleID string) bool {
 	const marker = "greenlight:ignore"
 	i := strings.Index(line, marker)

--- a/internal/codescan/rules.go
+++ b/internal/codescan/rules.go
@@ -379,22 +379,40 @@ func (r *PatternRule) Check(fc FileContext) []Finding {
 // every rule; `greenlight:ignore <rule-id>[ <rule-id>...]` suppresses only the
 // listed rules.
 func suppressedByIgnore(lines []string, lineNum int, ruleID string) bool {
+	// A directive on this line (trailing or standalone) suppresses this line.
 	if directiveSuppresses(lines[lineNum], ruleID) {
 		return true
 	}
-	return lineNum > 0 && directiveSuppresses(lines[lineNum-1], ruleID)
+	// The line above carries to this line only when it is a STANDALONE directive
+	// comment — otherwise a trailing directive on a code line would also silence
+	// a real finding on the next line.
+	if lineNum > 0 {
+		above := strings.TrimSpace(lines[lineNum-1])
+		if isCommentLine(above) && directiveSuppresses(above, ruleID) {
+			return true
+		}
+	}
+	return false
+}
+
+func isCommentLine(trimmed string) bool {
+	return strings.HasPrefix(trimmed, "//") ||
+		strings.HasPrefix(trimmed, "/*") ||
+		strings.HasPrefix(trimmed, "*") ||
+		strings.HasPrefix(trimmed, "<!--")
 }
 
 // directiveSuppresses reports whether line carries a directive suppressing
-// ruleID. The marker is matched as a plain substring (no comment/string parsing).
-// A directive with no trailing tokens is "bare" and suppresses every rule;
-// otherwise each whitespace/comma-separated token is matched against ruleID, so
-// `greenlight:ignore <id> <reason>` works but `greenlight:ignore <reason>` (no
-// id) does NOT blanket-suppress — use a bare directive for that.
+// ruleID. The marker must be the first token of a comment (only whitespace
+// between the comment opener and the marker) so prose that merely mentions
+// "greenlight:ignore" is not a directive. A directive with no trailing tokens is
+// "bare" and suppresses every rule; otherwise each whitespace/comma-separated
+// token is matched against ruleID, so `greenlight:ignore <id> <reason>` works
+// but `greenlight:ignore <reason>` (no id) does NOT blanket-suppress.
 func directiveSuppresses(line, ruleID string) bool {
 	const marker = "greenlight:ignore"
 	i := strings.Index(line, marker)
-	if i < 0 {
+	if i < 0 || !commentOpensJustBefore(line[:i]) {
 		return false
 	}
 	rest := strings.TrimSpace(line[i+len(marker):])
@@ -414,6 +432,13 @@ func directiveSuppresses(line, ruleID string) bool {
 		}
 	}
 	return false
+}
+
+// commentOpensJustBefore reports whether the text immediately preceding the
+// marker is a comment opener followed only by whitespace.
+func commentOpensJustBefore(before string) bool {
+	t := strings.TrimRight(before, " \t")
+	return strings.HasSuffix(t, "//") || strings.HasSuffix(t, "/*") || strings.HasSuffix(t, "<!--")
 }
 
 // PlistKeyRule checks Info.plist for required privacy keys when certain frameworks are detected.

--- a/internal/codescan/rules.go
+++ b/internal/codescan/rules.go
@@ -340,6 +340,11 @@ func (r *PatternRule) Check(fc FileContext) []Finding {
 
 		for _, pattern := range r.patterns {
 			if pattern.MatchString(line) {
+				// Honor an inline `// greenlight:ignore[ rule-id]` directive on the
+				// matching line or the line directly above it.
+				if suppressedByIgnore(fc.Lines, lineNum, r.id) {
+					break
+				}
 				findings = append(findings, Finding{
 					Severity:  r.severity,
 					Guideline: r.guideline,
@@ -367,6 +372,42 @@ func (r *PatternRule) Check(fc FileContext) []Finding {
 	}
 
 	return findings
+}
+
+// suppressedByIgnore reports whether the matching line, or the line directly
+// above it, carries a `greenlight:ignore` directive. A bare directive suppresses
+// every rule; `greenlight:ignore <rule-id>[ <rule-id>...]` suppresses only the
+// listed rules.
+func suppressedByIgnore(lines []string, lineNum int, ruleID string) bool {
+	if directiveSuppresses(lines[lineNum], ruleID) {
+		return true
+	}
+	return lineNum > 0 && directiveSuppresses(lines[lineNum-1], ruleID)
+}
+
+func directiveSuppresses(line, ruleID string) bool {
+	const marker = "greenlight:ignore"
+	i := strings.Index(line, marker)
+	if i < 0 {
+		return false
+	}
+	rest := strings.TrimSpace(line[i+len(marker):])
+	rest = strings.TrimLeft(rest, ":= \t")
+	// Drop a trailing comment close so `/* greenlight:ignore */` and the XML
+	// `<!-- greenlight:ignore -->` forms register as bare directives.
+	rest = strings.TrimSpace(strings.TrimSuffix(rest, "-->"))
+	rest = strings.TrimSpace(strings.TrimSuffix(rest, "*/"))
+	if rest == "" {
+		return true // bare directive: suppress every rule on the line
+	}
+	for _, tok := range strings.FieldsFunc(rest, func(r rune) bool {
+		return r == ' ' || r == ',' || r == '\t'
+	}) {
+		if tok == ruleID {
+			return true
+		}
+	}
+	return false
 }
 
 // PlistKeyRule checks Info.plist for required privacy keys when certain frameworks are detected.

--- a/internal/codescan/rules_test.go
+++ b/internal/codescan/rules_test.go
@@ -17,6 +17,33 @@ func swiftCtx(lines ...string) FileContext {
 	return FileContext{Path: "X.swift", RelPath: "X.swift", Lines: lines, Language: "swift"}
 }
 
+// An inline `// greenlight:ignore` directive (bare or rule-specific), on the
+// matching line or the line directly above it, suppresses the finding.
+func TestInlineIgnoreDirective(t *testing.T) {
+	r := ruleByID(t, "hardcoded-ipv4")
+
+	suppressed := []FileContext{
+		swiftCtx(`let host = "10.1.2.3" // greenlight:ignore`),                   // bare, same line
+		swiftCtx(`let host = "10.1.2.3" // greenlight:ignore hardcoded-ipv4`),    // rule-specific, same line
+		swiftCtx(`// greenlight:ignore hardcoded-ipv4`, `let host = "10.1.2.3"`), // directive on line above
+		swiftCtx(`/* greenlight:ignore */`, `let host = "10.1.2.3"`),             // block-comment bare
+	}
+	for i, ctx := range suppressed {
+		if got := r.Check(ctx); len(got) != 0 {
+			t.Errorf("case %d: expected suppression, got %d findings: %+v", i, len(got), got)
+		}
+	}
+
+	// A directive naming a different rule must NOT suppress this one; and with no
+	// directive the rule still fires.
+	if got := r.Check(swiftCtx(`let host = "10.1.2.3" // greenlight:ignore some-other-rule`)); len(got) == 0 {
+		t.Error("a directive for a different rule should not suppress this finding")
+	}
+	if got := r.Check(swiftCtx(`let host = "10.1.2.3"`)); len(got) == 0 {
+		t.Error("expected a finding when no ignore directive is present")
+	}
+}
+
 // The §2.1 placeholder-content rule must not fire on SwiftUI's `placeholder:`
 // parameter or example hint text. It used to match the bare word "placeholder",
 // turning normal apps into dozens of warnings; re-adding it would fail this test.

--- a/internal/codescan/rules_test.go
+++ b/internal/codescan/rules_test.go
@@ -42,6 +42,25 @@ func TestInlineIgnoreDirective(t *testing.T) {
 	if got := r.Check(swiftCtx(`let host = "10.1.2.3"`)); len(got) == 0 {
 		t.Error("expected a finding when no ignore directive is present")
 	}
+
+	// A TRAILING directive on a code line must suppress only its own line, not a
+	// real finding on the line below.
+	leak := swiftCtx(
+		`let a = "10.1.2.3" // greenlight:ignore hardcoded-ipv4`,
+		`let b = "192.168.5.5"`,
+	)
+	if got := r.Check(leak); len(got) != 1 {
+		t.Errorf("trailing directive must not leak to the next line; want 1 finding, got %d: %+v", len(got), got)
+	}
+
+	// A prose comment that merely mentions the marker is not a directive.
+	prose := swiftCtx(
+		`// To silence this, add greenlight:ignore`,
+		`let host = "10.1.2.3"`,
+	)
+	if got := r.Check(prose); len(got) != 1 {
+		t.Errorf("prose mentioning the marker must not suppress; want 1 finding, got %d: %+v", len(got), got)
+	}
 }
 
 // The §2.1 placeholder-content rule must not fire on SwiftUI's `placeholder:`

--- a/internal/ipa/inspect.go
+++ b/internal/ipa/inspect.go
@@ -231,8 +231,8 @@ func (r *InspectResult) checkInfoPlist(files map[string]*zip.File, appDir string
 		guideline string
 		title     string
 	}{
-		"CFBundleDisplayName":   {"2.3", "Missing CFBundleDisplayName"},
-		"CFBundleVersion":      {"2.1", "Missing CFBundleVersion (build number)"},
+		"CFBundleDisplayName":        {"2.3", "Missing CFBundleDisplayName"},
+		"CFBundleVersion":            {"2.1", "Missing CFBundleVersion (build number)"},
 		"CFBundleShortVersionString": {"2.1", "Missing CFBundleShortVersionString (version)"},
 	}
 

--- a/internal/preflight/metadata.go
+++ b/internal/preflight/metadata.go
@@ -78,7 +78,7 @@ type expoConfig struct {
 			InfoPlist        map[string]interface{} `json:"infoPlist"`
 			PrivacyManifests interface{}            `json:"privacyManifests"`
 		} `json:"ios"`
-		Icon    string `json:"icon"`
+		Icon    string        `json:"icon"`
 		Plugins []interface{} `json:"plugins"`
 	} `json:"expo"`
 }
@@ -295,17 +295,17 @@ func checkInfoPlistLocal(data []byte, plistPath, projectPath string) ([]Finding,
 
 	// Check purpose strings quality
 	purposeStrings := map[string]string{
-		"NSCameraUsageDescription":              "Camera",
-		"NSMicrophoneUsageDescription":          "Microphone",
-		"NSPhotoLibraryUsageDescription":        "Photo Library",
-		"NSLocationWhenInUseUsageDescription":   "Location",
-		"NSLocationAlwaysUsageDescription":      "Location (Always)",
-		"NSUserTrackingUsageDescription":        "User Tracking",
-		"NSFaceIDUsageDescription":              "Face ID",
-		"NSContactsUsageDescription":            "Contacts",
-		"NSCalendarsUsageDescription":           "Calendars",
-		"NSHealthShareUsageDescription":         "HealthKit",
-		"NSBluetoothAlwaysUsageDescription":     "Bluetooth",
+		"NSCameraUsageDescription":            "Camera",
+		"NSMicrophoneUsageDescription":        "Microphone",
+		"NSPhotoLibraryUsageDescription":      "Photo Library",
+		"NSLocationWhenInUseUsageDescription": "Location",
+		"NSLocationAlwaysUsageDescription":    "Location (Always)",
+		"NSUserTrackingUsageDescription":      "User Tracking",
+		"NSFaceIDUsageDescription":            "Face ID",
+		"NSContactsUsageDescription":          "Contacts",
+		"NSCalendarsUsageDescription":         "Calendars",
+		"NSHealthShareUsageDescription":       "HealthKit",
+		"NSBluetoothAlwaysUsageDescription":   "Bluetooth",
 	}
 
 	for key, name := range purposeStrings {

--- a/internal/preflight/runner.go
+++ b/internal/preflight/runner.go
@@ -11,7 +11,7 @@ import (
 
 // Finding is the unified finding type across all scanners.
 type Finding struct {
-	Source    string `json:"source"` // "codescan", "privacy", "ipa", "metadata"
+	Source    string `json:"source"`   // "codescan", "privacy", "ipa", "metadata"
 	Severity  string `json:"severity"` // "CRITICAL", "WARN", "INFO"
 	Guideline string `json:"guideline,omitempty"`
 	Title     string `json:"title"`
@@ -24,10 +24,10 @@ type Finding struct {
 
 // Result holds the combined output from all scanners.
 type Result struct {
-	ProjectPath string    `json:"project_path"`
-	IPAPath     string    `json:"ipa_path,omitempty"`
-	Findings    []Finding `json:"findings"`
-	Summary     Summary   `json:"summary"`
+	ProjectPath string        `json:"project_path"`
+	IPAPath     string        `json:"ipa_path,omitempty"`
+	Findings    []Finding     `json:"findings"`
+	Summary     Summary       `json:"summary"`
 	Elapsed     time.Duration `json:"elapsed"`
 
 	// Extra context from sub-scanners

--- a/internal/privacy/scanner.go
+++ b/internal/privacy/scanner.go
@@ -31,12 +31,12 @@ type RequiredReasonAPI struct {
 
 // ScanResult holds the full privacy scan output.
 type ScanResult struct {
-	ProjectPath     string    `json:"project_path"`
-	HasPrivacyInfo  bool      `json:"has_privacy_info"`
-	DetectedAPIs    []string  `json:"detected_apis"`
-	DeclaredAPIs    []string  `json:"declared_apis"`
-	TrackingSDKs    []string  `json:"tracking_sdks,omitempty"`
-	Findings        []Finding `json:"findings"`
+	ProjectPath    string    `json:"project_path"`
+	HasPrivacyInfo bool      `json:"has_privacy_info"`
+	DetectedAPIs   []string  `json:"detected_apis"`
+	DeclaredAPIs   []string  `json:"declared_apis"`
+	TrackingSDKs   []string  `json:"tracking_sdks,omitempty"`
+	Findings       []Finding `json:"findings"`
 }
 
 var requiredReasonAPIs = []RequiredReasonAPI{

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -7,8 +7,8 @@ import (
 	"io"
 	"time"
 
-	"github.com/fatih/color"
 	"github.com/RevylAI/greenlight/internal/checks"
+	"github.com/fatih/color"
 )
 
 var (


### PR DESCRIPTION
Second of three PRs from the scanner review. Tier 1: quality-of-life and CI hygiene. No verdict-changing behavior here.

## Changes
- version: `greenlight --version` now works, and `go install ...@latest` reports the embedded module version instead of "dev" (runtime/debug build-info fallback; ldflags release builds still win). `--version` and the `version` subcommand print the same wording.
- checks: App Store metadata length checks (name, description, keywords, promo text) count characters with utf8.RuneCountInString, not bytes, so non-ASCII metadata is not falsely flagged as over Apple's limits.
- codescan: inline `// greenlight:ignore[ rule-id]` directive on the matching line or the line directly above suppresses a finding (bare = all rules on the line).
- CI: new `format` job that fails on non-gofmt'd code; tests run with -race; build/vet/test run on ubuntu and macos.
- gofmt -w across the repo to clear the pre-existing format backlog (its own commit, formatting only, so the new gofmt gate stays green).

Tests added for version resolution, UTF-8 counting, and the ignore directive.

## Notes
- golangci-lint is intentionally not wired into CI yet: it could not be verified locally here and the never-linted code would likely make CI red. Follow-up: add a .golangci.yml baseline, then enable it.
- Deferred from this PR (bigger than QOL): cross-scanner finding dedup and ASC retry/pagination. Tracked for later.