### PR TITLE
Add UIWebView-removed CRITICAL + encryption export-compliance check

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Scans Swift, Objective-C, React Native, and Expo projects for:
 - External payment for digital goods (§3.1.1) — **CRITICAL**
 - Dynamic code execution (§2.5.2) — **CRITICAL**
 - Cryptocurrency mining (§3.1.5) — **CRITICAL**
+- UIWebView (removed API, hard rejection) (§2.5.1) — **CRITICAL**
 - Missing Sign in with Apple when using social login (§4.8)
 - Missing Restore Purchases for IAP (§3.1.1)
 - Missing ATT for ad/tracking SDKs (§5.1.2)
@@ -76,6 +77,7 @@ Scans Swift, Objective-C, React Native, and Expo projects for:
 - Hardcoded IPv4 addresses (§2.5)
 - Insecure HTTP URLs (§1.6)
 - Vague Info.plist purpose strings (§5.1.1)
+- Missing encryption export-compliance declaration
 - Expo config issues (§2.1)
 
 ### `greenlight privacy [path]` — Privacy manifest validator

--- a/internal/cli/codescan.go
+++ b/internal/cli/codescan.go
@@ -32,6 +32,7 @@ Checks for:
   • Hardcoded secrets (CRITICAL)
   • External payment for digital goods (CRITICAL)
   • Dynamic code execution (CRITICAL)
+  • UIWebView, a removed API (CRITICAL)
   • Missing Sign in with Apple when using social login
   • Missing Restore Purchases for IAP
   • Missing ATT for ad/tracking SDKs
@@ -41,6 +42,7 @@ Checks for:
   • Hardcoded IPv4 addresses
   • Insecure HTTP URLs
   • Vague Info.plist purpose strings
+  • Missing encryption export-compliance declaration
   • Expo config issues`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runCodescan,

--- a/internal/codescan/rules.go
+++ b/internal/codescan/rules.go
@@ -249,6 +249,20 @@ func AllRules() []Rule {
 			},
 		},
 		&PatternRule{
+			id:        "uiwebview-removed",
+			title:     "UIWebView is no longer accepted",
+			guideline: "2.5.1",
+			severity:  SeverityCritical,
+			detail:    "Apple stopped accepting apps and updates that use the deprecated UIWebView API. Its presence is a hard rejection.",
+			fix:       "Migrate to WKWebView.",
+			languages: []string{"swift", "objc"},
+			patterns: []*regexp.Regexp{
+				// Prefix match so UIWebViewDelegate etc. are caught; the word
+				// boundary avoids custom names like MyUIWebView.
+				regexp.MustCompile(`\bUIWebView`),
+			},
+		},
+		&PatternRule{
 			id:        "vague-purpose-string",
 			title:     "Vague permission purpose string",
 			guideline: "5.1.1",
@@ -269,6 +283,9 @@ func AllRules() []Rule {
 		},
 		&ExpoConfigRule{
 			id: "expo-config-check",
+		},
+		&ExportComplianceRule{
+			id: "export-compliance",
 		},
 	}
 }
@@ -472,4 +489,45 @@ func (r *ExpoConfigRule) Check(fc FileContext) []Finding {
 	}
 
 	return findings
+}
+
+// ExportComplianceRule flags an Info.plist or Expo config that does not declare
+// encryption export compliance. Without it, App Store Connect prompts for export
+// compliance on every single upload.
+type ExportComplianceRule struct {
+	id string
+}
+
+func (r *ExportComplianceRule) Applies(fc FileContext) bool {
+	if fc.Language == "plist" && strings.HasSuffix(strings.ToLower(fc.RelPath), "info.plist") {
+		return true
+	}
+	// Match the Expo config files by exact name, not a trimmed basename — source
+	// like App.tsx / app.js also collapses to "app" and would false-positive.
+	switch strings.ToLower(filepath.Base(fc.RelPath)) {
+	case "app.json", "app.config.js", "app.config.ts":
+		return true
+	}
+	return false
+}
+
+func (r *ExportComplianceRule) Check(fc FileContext) []Finding {
+	content := strings.Join(fc.Lines, "\n")
+	// Already declared — Info.plist uses ITSAppUsesNonExemptEncryption; Expo
+	// app.json uses ios.config.usesNonExemptEncryption.
+	if strings.Contains(content, "ITSAppUsesNonExemptEncryption") ||
+		strings.Contains(content, "usesNonExemptEncryption") {
+		return nil
+	}
+	// For Expo configs, only flag a file that actually defines an app.
+	if fc.Language != "plist" && !strings.Contains(content, `"expo"`) {
+		return nil
+	}
+	return []Finding{{
+		Severity: SeverityInfo,
+		Title:    "No encryption export-compliance declaration",
+		Detail:   "Without an export-compliance declaration, App Store Connect asks about export compliance on every upload.",
+		Fix:      "Set ITSAppUsesNonExemptEncryption in Info.plist (or ios.config.usesNonExemptEncryption in app.json): false if you only use exempt encryption like HTTPS, true (with documentation) otherwise.",
+		File:     fc.RelPath,
+	}}
 }

--- a/internal/codescan/rules.go
+++ b/internal/codescan/rules.go
@@ -257,9 +257,12 @@ func AllRules() []Rule {
 			fix:       "Migrate to WKWebView.",
 			languages: []string{"swift", "objc"},
 			patterns: []*regexp.Regexp{
-				// Prefix match so UIWebViewDelegate etc. are caught; the word
-				// boundary avoids custom names like MyUIWebView.
-				regexp.MustCompile(`\bUIWebView`),
+				// Require a real usage context (call, ObjC pointer, type position,
+				// or the Delegate protocol) so a mention inside a string literal or
+				// a trailing comment doesn't trip this CRITICAL rule.
+				regexp.MustCompile(`\bUIWebView\s*[(*]`), // UIWebView(  /  UIWebView *
+				regexp.MustCompile(`\bUIWebViewDelegate\b`),
+				regexp.MustCompile(`[:\[]\s*UIWebView\b`), // : UIWebView  /  [UIWebView
 			},
 		},
 		&PatternRule{
@@ -491,6 +494,10 @@ func (r *ExpoConfigRule) Check(fc FileContext) []Finding {
 	return findings
 }
 
+// expoKeyRE matches the unquoted `expo:` key used in app.config.js / app.config.ts
+// (app.json uses the quoted "expo" form).
+var expoKeyRE = regexp.MustCompile(`\bexpo\s*:`)
+
 // ExportComplianceRule flags an Info.plist or Expo config that does not declare
 // encryption export compliance. Without it, App Store Connect prompts for export
 // compliance on every single upload.
@@ -519,8 +526,9 @@ func (r *ExportComplianceRule) Check(fc FileContext) []Finding {
 		strings.Contains(content, "usesNonExemptEncryption") {
 		return nil
 	}
-	// For Expo configs, only flag a file that actually defines an app.
-	if fc.Language != "plist" && !strings.Contains(content, `"expo"`) {
+	// For Expo configs, only flag a file that actually defines an app. app.json
+	// uses the quoted "expo" key; app.config.js/ts use an unquoted `expo:`.
+	if fc.Language != "plist" && !strings.Contains(content, `"expo"`) && !expoKeyRE.MatchString(content) {
 		return nil
 	}
 	return []Finding{{

--- a/internal/codescan/rules.go
+++ b/internal/codescan/rules.go
@@ -258,12 +258,13 @@ func AllRules() []Rule {
 			languages: []string{"swift", "objc"},
 			patterns: []*regexp.Regexp{
 				// Require a real usage context (call, ObjC pointer, type position,
-				// or the Delegate protocol) so a mention inside a string literal or
-				// a trailing comment doesn't trip this CRITICAL rule.
+				// or the Delegate protocol). codeOnly below also blanks string
+				// literals + comments so a textual mention can't trip this CRITICAL.
 				regexp.MustCompile(`\bUIWebView\s*[(*]`), // UIWebView(  /  UIWebView *
 				regexp.MustCompile(`\bUIWebViewDelegate\b`),
 				regexp.MustCompile(`[:\[]\s*UIWebView\b`), // : UIWebView  /  [UIWebView
 			},
+			codeOnly: true,
 		},
 		&PatternRule{
 			id:        "vague-purpose-string",
@@ -308,6 +309,7 @@ type PatternRule struct {
 	ignorePatterns     []*regexp.Regexp // Lines matching these are skipped
 	countThreshold     int              // Only report if count exceeds this
 	firstMatchOnly     bool             // Project-level fact: cap to one per file; scanner collapses to one per project
+	codeOnly           bool             // Strip string literals + comments before matching (for rules that must not fire on text)
 }
 
 func (r *PatternRule) RuleID() string { return r.id }
@@ -358,8 +360,15 @@ func (r *PatternRule) Check(fc FileContext) []Finding {
 			continue
 		}
 
+		// codeOnly rules match against a copy with string literals and comments
+		// blanked out, so a mention in text (e.g. "use UIWebView()") doesn't fire.
+		matchLine := line
+		if r.codeOnly {
+			matchLine = stripStringsAndComments(line)
+		}
+
 		for _, pattern := range r.patterns {
-			if pattern.MatchString(line) {
+			if pattern.MatchString(matchLine) {
 				findings = append(findings, Finding{
 					Severity:  r.severity,
 					Guideline: r.guideline,
@@ -387,6 +396,45 @@ func (r *PatternRule) Check(fc FileContext) []Finding {
 	}
 
 	return findings
+}
+
+// stripStringsAndComments blanks out the contents of "..."/'...' string literals
+// and removes // line comments and /* */ block comments, so codeOnly rules match
+// only real code. It's a lightweight scan (no escaped-quote handling), which is
+// enough to keep call-shaped text like "UIWebView()" out of the match.
+func stripStringsAndComments(line string) string {
+	var b strings.Builder
+	b.Grow(len(line))
+	inStr := false
+	var quote byte
+	for i := 0; i < len(line); i++ {
+		c := line[i]
+		if inStr {
+			b.WriteByte(' ')
+			if c == quote {
+				inStr = false
+			}
+			continue
+		}
+		switch {
+		case c == '"' || c == '\'' || c == '`':
+			inStr = true
+			quote = c
+			b.WriteByte(' ')
+		case c == '/' && i+1 < len(line) && line[i+1] == '/':
+			return b.String() // rest of the line is a comment
+		case c == '/' && i+1 < len(line) && line[i+1] == '*':
+			end := strings.Index(line[i+2:], "*/")
+			if end < 0 {
+				return b.String() // unterminated block comment
+			}
+			i += end + 3 // skip past the closing */
+			b.WriteByte(' ')
+		default:
+			b.WriteByte(c)
+		}
+	}
+	return b.String()
 }
 
 // PlistKeyRule checks Info.plist for required privacy keys when certain frameworks are detected.

--- a/internal/codescan/rules_test.go
+++ b/internal/codescan/rules_test.go
@@ -30,7 +30,15 @@ func TestUIWebViewRemoved(t *testing.T) {
 			t.Errorf("%q: severity = %v, want CRITICAL", line, got[0].Severity)
 		}
 	}
-	for _, line := range []string{`let w = WKWebView()`, `let x = MyUIWebView()`, `let y = MyUIWebViewWrapper()`} {
+	negatives := []string{
+		`let w = WKWebView()`,
+		`let x = MyUIWebView()`,
+		`let y = MyUIWebViewWrapper()`,
+		`let s = "UIWebView"`,                            // string literal, not usage
+		`logEvent("UIWebView_fallback_shown")`,           // identifier inside a string
+		`let w = WKWebView() // migrated from UIWebView`, // trailing-comment mention
+	}
+	for _, line := range negatives {
 		if got := r.Check(swiftCtx(line)); len(got) != 0 {
 			t.Errorf("did not expect a finding for %q, got %+v", line, got)
 		}
@@ -72,6 +80,16 @@ func TestExportCompliance(t *testing.T) {
 	expoNoKey := FileContext{RelPath: "app.json", Language: "json", Lines: []string{`{"expo":{"name":"X","ios":{"bundleIdentifier":"a.b"}}}`}}
 	if got := r.Check(expoNoKey); len(got) == 0 {
 		t.Error("expected a finding for an Expo app.json without usesNonExemptEncryption")
+	}
+
+	// app.config.js uses an unquoted `expo:` key — the rule must still fire (this
+	// was dead code: the "expo" quoted gate never matched JS/TS configs).
+	expoConfigJS := FileContext{RelPath: "app.config.js", Language: "javascript", Lines: []string{`export default { expo: { name: "X" } }`}}
+	if !r.Applies(expoConfigJS) {
+		t.Error("should apply to app.config.js")
+	}
+	if got := r.Check(expoConfigJS); len(got) == 0 {
+		t.Error("expected a finding for app.config.js without usesNonExemptEncryption")
 	}
 
 	expoWithKey := FileContext{RelPath: "app.json", Language: "json", Lines: []string{`{"expo":{"ios":{"config":{"usesNonExemptEncryption":false}}}}`}}

--- a/internal/codescan/rules_test.go
+++ b/internal/codescan/rules_test.go
@@ -17,6 +17,75 @@ func swiftCtx(lines ...string) FileContext {
 	return FileContext{Path: "X.swift", RelPath: "X.swift", Lines: lines, Language: "swift"}
 }
 
+// UIWebView is a removed API and a hard rejection; the rule must flag it (and
+// UIWebViewDelegate) as CRITICAL but not WKWebView or custom-named types.
+func TestUIWebViewRemoved(t *testing.T) {
+	r := ruleByID(t, "uiwebview-removed")
+
+	for _, line := range []string{`let w = UIWebView()`, `class C: UIWebViewDelegate {}`, `UIWebView *w = [UIWebView new];`} {
+		got := r.Check(swiftCtx(line))
+		if len(got) == 0 {
+			t.Errorf("expected a finding for %q", line)
+		} else if got[0].Severity != SeverityCritical {
+			t.Errorf("%q: severity = %v, want CRITICAL", line, got[0].Severity)
+		}
+	}
+	for _, line := range []string{`let w = WKWebView()`, `let x = MyUIWebView()`, `let y = MyUIWebViewWrapper()`} {
+		if got := r.Check(swiftCtx(line)); len(got) != 0 {
+			t.Errorf("did not expect a finding for %q, got %+v", line, got)
+		}
+	}
+}
+
+// Export-compliance: flag an Info.plist / Expo config that doesn't declare it,
+// but stay quiet once it's declared or for non-Expo json.
+func TestExportCompliance(t *testing.T) {
+	r := &ExportComplianceRule{id: "export-compliance"}
+
+	// Applies: Info.plist and the Expo config files, but NOT App.tsx / app.js source.
+	if !r.Applies(FileContext{RelPath: "ios/App/Info.plist", Language: "plist"}) {
+		t.Error("should apply to Info.plist")
+	}
+	if !r.Applies(FileContext{RelPath: "app.config.ts", Language: "typescript"}) {
+		t.Error("should apply to app.config.ts")
+	}
+	if r.Applies(FileContext{RelPath: "App.tsx", Language: "typescript"}) {
+		t.Error("must NOT apply to App.tsx source")
+	}
+	if r.Applies(FileContext{RelPath: "src/app.js", Language: "javascript"}) {
+		t.Error("must NOT apply to app.js source")
+	}
+
+	infoNoKey := FileContext{RelPath: "Info.plist", Language: "plist", Lines: []string{"<key>CFBundleName</key><string>X</string>"}}
+	if !r.Applies(infoNoKey) {
+		t.Fatal("rule should apply to Info.plist")
+	}
+	if got := r.Check(infoNoKey); len(got) == 0 || got[0].Severity != SeverityInfo {
+		t.Errorf("expected an INFO finding for Info.plist without the key, got %+v", got)
+	}
+
+	infoWithKey := FileContext{RelPath: "Info.plist", Language: "plist", Lines: []string{"<key>ITSAppUsesNonExemptEncryption</key><false/>"}}
+	if got := r.Check(infoWithKey); len(got) != 0 {
+		t.Errorf("no finding expected when the key is present, got %+v", got)
+	}
+
+	expoNoKey := FileContext{RelPath: "app.json", Language: "json", Lines: []string{`{"expo":{"name":"X","ios":{"bundleIdentifier":"a.b"}}}`}}
+	if got := r.Check(expoNoKey); len(got) == 0 {
+		t.Error("expected a finding for an Expo app.json without usesNonExemptEncryption")
+	}
+
+	expoWithKey := FileContext{RelPath: "app.json", Language: "json", Lines: []string{`{"expo":{"ios":{"config":{"usesNonExemptEncryption":false}}}}`}}
+	if got := r.Check(expoWithKey); len(got) != 0 {
+		t.Errorf("no finding expected when usesNonExemptEncryption is set, got %+v", got)
+	}
+
+	// A non-Expo json (e.g. some other app.json) must not trip it.
+	nonExpo := FileContext{RelPath: "app.json", Language: "json", Lines: []string{`{"name":"not-expo"}`}}
+	if got := r.Check(nonExpo); len(got) != 0 {
+		t.Errorf("no finding expected for non-Expo json, got %+v", got)
+	}
+}
+
 // The §2.1 placeholder-content rule must not fire on SwiftUI's `placeholder:`
 // parameter or example hint text. It used to match the bare word "placeholder",
 // turning normal apps into dozens of warnings; re-adding it would fail this test.

--- a/internal/codescan/rules_test.go
+++ b/internal/codescan/rules_test.go
@@ -34,9 +34,11 @@ func TestUIWebViewRemoved(t *testing.T) {
 		`let w = WKWebView()`,
 		`let x = MyUIWebView()`,
 		`let y = MyUIWebViewWrapper()`,
-		`let s = "UIWebView"`,                            // string literal, not usage
-		`logEvent("UIWebView_fallback_shown")`,           // identifier inside a string
-		`let w = WKWebView() // migrated from UIWebView`, // trailing-comment mention
+		`let s = "UIWebView"`,                              // string literal, not usage
+		`logEvent("UIWebView_fallback_shown")`,             // identifier inside a string
+		`let w = WKWebView() // migrated from UIWebView`,   // trailing-comment mention
+		`let message = "Remove UIWebView() from old docs"`, // call-shaped text in a string
+		`let web = WKWebView() // TODO remove UIWebView()`, // call-shaped text in a comment
 	}
 	for _, line := range negatives {
 		if got := r.Check(swiftCtx(line)); len(got) != 0 {


### PR DESCRIPTION
Tier 2, feature 2 from the scanner review. Two new rejection-risk rules.

## Rules
- uiwebview-removed (CRITICAL, §2.5.1): Apple stopped accepting apps and updates that use UIWebView, so its presence is a hard rejection. Prefix-matched so UIWebViewDelegate is caught; word boundary so custom names like MyUIWebView are not. Swift / Objective-C.
- export-compliance (INFO): flags an Info.plist or Expo config (app.json / app.config.{js,ts}) that doesn't declare encryption export compliance. Without ITSAppUsesNonExemptEncryption (or ios.config.usesNonExemptEncryption), App Store Connect prompts for export compliance on every upload.

## Notes
- export-compliance matches Expo config files by exact name, not a trimmed basename, so source like App.tsx / app.js does not false-positive (this was caught and fixed in review).
- Known limitation: in a multi-target native project, each Info.plist (extensions, test bundles) gets its own INFO, though only the main app target needs the key. Acceptable for an INFO; can dedup later.
- README and codescan --help updated. Tests for both rules.

Separately reviewed; build/vet/test green.