### PR TITLE
Add SARIF output (--format sarif) for codescan + preflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,18 @@ All scan commands support:
 ```bash
 --format terminal   # colored terminal output (default)
 --format json       # JSON for CI/CD pipelines
+--format sarif      # SARIF 2.1.0 for GitHub code scanning (preflight, codescan)
 --output file.json  # write to file instead of stdout
+```
+
+Upload `--format sarif` to GitHub code scanning to get findings inline in the
+Security tab and on PRs:
+
+```yaml
+- run: greenlight preflight . --format sarif --output greenlight.sarif
+- uses: github/codeql-action/upload-sarif@v3
+  with:
+    sarif_file: greenlight.sarif
 ```
 
 ## Claude Code Skill

--- a/internal/cli/codescan.go
+++ b/internal/cli/codescan.go
@@ -8,10 +8,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/fatih/color"
 	"github.com/RevylAI/greenlight/internal/codescan"
+	"github.com/RevylAI/greenlight/internal/sarif"
+	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
+
+const greenlightInfoURI = "https://github.com/RevylAI/greenlight"
 
 var (
 	codescanPath   string
@@ -47,7 +50,7 @@ Checks for:
 }
 
 func init() {
-	codescanCmd.Flags().StringVar(&codescanFormat, "format", "terminal", "output format: terminal, json")
+	codescanCmd.Flags().StringVar(&codescanFormat, "format", "terminal", "output format: terminal, json, sarif")
 	codescanCmd.Flags().StringVar(&codescanOutput, "output", "", "write report to file (stdout if omitted)")
 	rootCmd.AddCommand(codescanCmd)
 }
@@ -67,10 +70,13 @@ func runCodescan(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("path must be a directory: %s", path)
 	}
 
-	// Banner
-	purple.Println("\n  greenlight codescan — find rejection risks in your code.")
-	fmt.Printf("  Scanning: %s\n", path)
-	fmt.Printf("  Format:   %s\n\n", codescanFormat)
+	// Banner (suppressed for machine formats so stdout stays valid JSON/SARIF).
+	format := strings.ToLower(codescanFormat)
+	if format != "json" && format != "sarif" {
+		purple.Println("\n  greenlight codescan — find rejection risks in your code.")
+		fmt.Printf("  Scanning: %s\n", path)
+		fmt.Printf("  Format:   %s\n\n", codescanFormat)
+	}
 
 	// Run scan
 	start := time.Now()
@@ -101,12 +107,29 @@ func runCodescan(cmd *cobra.Command, args []string) error {
 		output = os.Stdout
 	}
 
-	switch strings.ToLower(codescanFormat) {
+	switch format {
 	case "json":
 		return writeCodescanJSON(output, findings, elapsed)
+	case "sarif":
+		return writeCodescanSARIF(output, findings)
 	default:
 		return writeCodescanTerminal(output, findings, elapsed)
 	}
+}
+
+func writeCodescanSARIF(w *os.File, findings []codescan.Finding) error {
+	sf := make([]sarif.Finding, 0, len(findings))
+	for _, f := range findings {
+		sf = append(sf, sarif.Finding{
+			Severity:  f.Severity.String(),
+			Title:     f.Title,
+			Detail:    f.Detail,
+			Guideline: f.Guideline,
+			File:      f.File,
+			Line:      f.Line,
+		})
+	}
+	return sarif.Write(w, "greenlight", appVersion, greenlightInfoURI, sf)
 }
 
 func writeCodescanTerminal(w *os.File, findings []codescan.Finding, elapsed time.Duration) error {

--- a/internal/cli/preflight.go
+++ b/internal/cli/preflight.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/RevylAI/greenlight/internal/preflight"
+	"github.com/RevylAI/greenlight/internal/sarif"
 	"github.com/RevylAI/greenlight/internal/verify"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -56,7 +57,7 @@ Usage:
 
 func init() {
 	preflightCmd.Flags().StringVar(&preflightIPA, "ipa", "", "path to .ipa file for binary inspection")
-	preflightCmd.Flags().StringVar(&preflightFormat, "format", "terminal", "output format: terminal, json")
+	preflightCmd.Flags().StringVar(&preflightFormat, "format", "terminal", "output format: terminal, json, sarif")
 	preflightCmd.Flags().StringVar(&preflightOutput, "output", "", "write report to file (stdout if omitted)")
 	preflightCmd.Flags().BoolVar(&preflightVerify, "verify", false, "after static checks, validate flow-dependent guidelines on a cloud device via Revyl")
 	preflightCmd.Flags().StringVar(&preflightBuildName, "build-name", "", "Revyl build/app name (for --verify)")
@@ -90,7 +91,7 @@ func runPreflight(cmd *cobra.Command, args []string) error {
 	}
 
 	// Banner (suppressed for --format json so stdout stays valid JSON).
-	if strings.ToLower(preflightFormat) != "json" {
+	if f := strings.ToLower(preflightFormat); f != "json" && f != "sarif" {
 		purple.Println("\n  greenlight preflight — every check, one command, zero uploads.")
 		fmt.Printf("  Project: %s\n", path)
 		if preflightIPA != "" {
@@ -123,13 +124,25 @@ func runPreflight(cmd *cobra.Command, args []string) error {
 		output = os.Stdout
 	}
 
-	isJSON := strings.ToLower(preflightFormat) == "json"
+	format := strings.ToLower(preflightFormat)
+	isJSON := format == "json"
+	isSARIF := format == "sarif"
+
+	// SARIF represents static code findings; runtime flow results aren't code
+	// locations. Reject the combination up front so we don't run (and bill) a
+	// device flow whose result the SARIF output would silently drop.
+	if isSARIF && preflightVerify {
+		return fmt.Errorf("--format sarif carries static findings only and can't represent --verify runtime results; use --format json for combined output, or run 'greenlight verify' separately")
+	}
 
 	// Default path: static only — offline, zero-account, instant, and complete
 	// on its own. The runtime tier is strictly opt-in; we only leave a light tip.
 	if !preflightVerify {
 		if isJSON {
 			return writePreflightJSON(output, result)
+		}
+		if isSARIF {
+			return writePreflightSARIF(output, result)
 		}
 		if err := writePreflightTerminal(output, result); err != nil {
 			return err
@@ -405,6 +418,21 @@ func writePreflightJSON(w *os.File, result *preflight.Result) error {
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
 	return enc.Encode(preflightJSONObject(result))
+}
+
+func writePreflightSARIF(w *os.File, result *preflight.Result) error {
+	sf := make([]sarif.Finding, 0, len(result.Findings))
+	for _, f := range result.Findings {
+		sf = append(sf, sarif.Finding{
+			Severity:  f.Severity,
+			Title:     f.Title,
+			Detail:    f.Detail,
+			Guideline: f.Guideline,
+			File:      f.File,
+			Line:      f.Line,
+		})
+	}
+	return sarif.Write(w, "greenlight", appVersion, greenlightInfoURI, sf)
 }
 
 // writeCombinedJSON emits the static result and the runtime (Revyl) result

--- a/internal/sarif/sarif.go
+++ b/internal/sarif/sarif.go
@@ -1,0 +1,176 @@
+// Package sarif renders compliance findings as a SARIF 2.1.0 log so they can be
+// uploaded to GitHub code scanning and shown inline (Security tab / PR
+// annotations) with file and line context.
+package sarif
+
+import (
+	"encoding/json"
+	"io"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// Finding is the minimal shape SARIF needs from any greenlight scanner.
+type Finding struct {
+	Severity  string // CRITICAL, HIGH, WARN, INFO
+	Title     string
+	Detail    string
+	Guideline string // Apple guideline section, e.g. "2.5.1" (optional)
+	File      string
+	Line      int // 1-indexed; 0 means no line
+}
+
+const schemaURL = "https://json.schemastore.org/sarif-2.1.0.json"
+
+// Write renders findings as a SARIF 2.1.0 document to w.
+func Write(w io.Writer, toolName, toolVersion, infoURI string, findings []Finding) error {
+	seen := map[string]bool{}
+	// Both must serialize as [] (not null) when empty — SARIF requires arrays.
+	rules := make([]rule, 0, len(findings))
+	results := make([]result, 0, len(findings))
+
+	for _, f := range findings {
+		id := ruleID(f)
+		if !seen[id] {
+			seen[id] = true
+			rules = append(rules, rule{
+				ID:               id,
+				Name:             f.Title,
+				ShortDescription: textBlock{Text: f.Title},
+			})
+		}
+		results = append(results, result{
+			RuleID:    id,
+			Level:     level(f.Severity),
+			Message:   textBlock{Text: messageText(f)},
+			Locations: locationsFor(f),
+		})
+	}
+
+	doc := sarifDoc{
+		Schema:  schemaURL,
+		Version: "2.1.0",
+		Runs: []run{{
+			Tool: tool{Driver: driver{
+				Name:           toolName,
+				Version:        toolVersion,
+				InformationURI: infoURI,
+				Rules:          rules,
+			}},
+			Results: results,
+		}},
+	}
+
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(doc)
+}
+
+func messageText(f Finding) string {
+	msg := f.Title
+	if f.Guideline != "" {
+		msg = "§" + f.Guideline + " " + msg
+	}
+	if f.Detail != "" {
+		msg += ". " + f.Detail
+	}
+	return msg
+}
+
+func locationsFor(f Finding) []location {
+	if f.File == "" {
+		return nil
+	}
+	loc := location{PhysicalLocation: physicalLocation{
+		ArtifactLocation: artifactLocation{URI: filepath.ToSlash(f.File)},
+	}}
+	if f.Line > 0 {
+		loc.PhysicalLocation.Region = &region{StartLine: f.Line}
+	}
+	return []location{loc}
+}
+
+// level maps a greenlight severity to a SARIF result level.
+func level(severity string) string {
+	switch strings.ToUpper(severity) {
+	case "CRITICAL", "HIGH":
+		return "error"
+	case "WARN", "WARNING":
+		return "warning"
+	default:
+		return "note"
+	}
+}
+
+var nonSlug = regexp.MustCompile(`[^a-z0-9]+`)
+
+// ruleID derives a stable SARIF rule id. greenlight findings don't carry the
+// internal rule id, so we slug the title (stable per rule) and prefix the
+// guideline when present so GitHub groups related findings.
+func ruleID(f Finding) string {
+	slug := strings.Trim(nonSlug.ReplaceAllString(strings.ToLower(f.Title), "-"), "-")
+	if slug == "" {
+		slug = "finding"
+	}
+	if f.Guideline != "" {
+		return "G" + f.Guideline + "/" + slug
+	}
+	return slug
+}
+
+type sarifDoc struct {
+	Schema  string `json:"$schema"`
+	Version string `json:"version"`
+	Runs    []run  `json:"runs"`
+}
+
+type run struct {
+	Tool    tool     `json:"tool"`
+	Results []result `json:"results"`
+}
+
+type tool struct {
+	Driver driver `json:"driver"`
+}
+
+type driver struct {
+	Name           string `json:"name"`
+	Version        string `json:"version,omitempty"`
+	InformationURI string `json:"informationUri,omitempty"`
+	Rules          []rule `json:"rules"`
+}
+
+type rule struct {
+	ID               string    `json:"id"`
+	Name             string    `json:"name,omitempty"`
+	ShortDescription textBlock `json:"shortDescription"`
+}
+
+type result struct {
+	RuleID    string     `json:"ruleId"`
+	Level     string     `json:"level"`
+	Message   textBlock  `json:"message"`
+	Locations []location `json:"locations,omitempty"`
+}
+
+type textBlock struct {
+	Text string `json:"text"`
+}
+
+type location struct {
+	PhysicalLocation physicalLocation `json:"physicalLocation"`
+}
+
+type physicalLocation struct {
+	ArtifactLocation artifactLocation `json:"artifactLocation"`
+	Region           *region          `json:"region,omitempty"`
+}
+
+type artifactLocation struct {
+	URI string `json:"uri"`
+}
+
+type region struct {
+	StartLine int `json:"startLine"`
+}

--- a/internal/sarif/sarif_test.go
+++ b/internal/sarif/sarif_test.go
@@ -1,0 +1,102 @@
+package sarif
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+func TestWriteProducesValidSARIF(t *testing.T) {
+	findings := []Finding{
+		{Severity: "CRITICAL", Title: "UIWebView is no longer accepted", Guideline: "2.5.1", File: "A.swift", Line: 3},
+		{Severity: "WARN", Title: "Hardcoded IPv4 address", Guideline: "2.5", File: "B.ts", Line: 10},
+		{Severity: "INFO", Title: "No encryption export-compliance declaration"}, // no file/line
+		{Severity: "CRITICAL", Title: "UIWebView is no longer accepted", Guideline: "2.5.1", File: "C.swift", Line: 5},
+	}
+
+	var buf bytes.Buffer
+	if err := Write(&buf, "greenlight", "v1.2.3", "https://example.com", findings); err != nil {
+		t.Fatal(err)
+	}
+
+	var doc map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &doc); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+	if doc["version"] != "2.1.0" {
+		t.Errorf("version = %v, want 2.1.0", doc["version"])
+	}
+
+	run := doc["runs"].([]interface{})[0].(map[string]interface{})
+	driver := run["tool"].(map[string]interface{})["driver"].(map[string]interface{})
+	if driver["name"] != "greenlight" || driver["version"] != "v1.2.3" {
+		t.Errorf("driver = %+v", driver)
+	}
+	// The two UIWebView findings share a rule id, so rules dedups to 3.
+	if rules := driver["rules"].([]interface{}); len(rules) != 3 {
+		t.Errorf("rules = %d, want 3 (dedup by rule id)", len(rules))
+	}
+
+	results := run["results"].([]interface{})
+	if len(results) != 4 {
+		t.Fatalf("results = %d, want 4", len(results))
+	}
+
+	// CRITICAL -> error, with a file+line location.
+	first := results[0].(map[string]interface{})
+	if first["level"] != "error" {
+		t.Errorf("CRITICAL level = %v, want error", first["level"])
+	}
+	loc := first["locations"].([]interface{})[0].(map[string]interface{})["physicalLocation"].(map[string]interface{})
+	if loc["artifactLocation"].(map[string]interface{})["uri"] != "A.swift" {
+		t.Errorf("uri = %+v, want A.swift", loc["artifactLocation"])
+	}
+	if loc["region"].(map[string]interface{})["startLine"].(float64) != 3 {
+		t.Errorf("startLine = %v, want 3", loc["region"])
+	}
+
+	// INFO with no file -> note, and no locations key.
+	third := results[2].(map[string]interface{})
+	if third["level"] != "note" {
+		t.Errorf("INFO level = %v, want note", third["level"])
+	}
+	if _, ok := third["locations"]; ok {
+		t.Error("a finding with no file should have no locations")
+	}
+}
+
+// Zero findings must still produce schema-valid SARIF: rules and results are
+// empty arrays, never null.
+func TestWriteEmptyFindings(t *testing.T) {
+	var buf bytes.Buffer
+	if err := Write(&buf, "greenlight", "v1", "", nil); err != nil {
+		t.Fatal(err)
+	}
+	// A literal "null" for either array is a schema violation.
+	if bytes.Contains(buf.Bytes(), []byte(`"rules": null`)) || bytes.Contains(buf.Bytes(), []byte(`"results": null`)) {
+		t.Fatalf("arrays must serialize as [], not null:\n%s", buf.String())
+	}
+	var doc map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &doc); err != nil {
+		t.Fatal(err)
+	}
+	run := doc["runs"].([]interface{})[0].(map[string]interface{})
+	if rules := run["tool"].(map[string]interface{})["driver"].(map[string]interface{})["rules"]; rules == nil {
+		t.Error("driver.rules is null, want []")
+	}
+	if results := run["results"]; results == nil {
+		t.Error("results is null, want []")
+	}
+}
+
+func TestLevelMapping(t *testing.T) {
+	for sev, want := range map[string]string{
+		"CRITICAL": "error", "HIGH": "error",
+		"WARN": "warning", "warning": "warning",
+		"INFO": "note", "": "note", "weird": "note",
+	} {
+		if got := level(sev); got != want {
+			t.Errorf("level(%q) = %q, want %q", sev, got, want)
+		}
+	}
+}


### PR DESCRIPTION
Tier 2, feature 3 from the scanner review. SARIF 2.1.0 output so findings upload to GitHub code scanning and show inline in the Security tab / on PRs.

## What
- New `internal/sarif` package renders findings as SARIF 2.1.0: severity -> level (CRITICAL/HIGH = error, WARN = warning, INFO = note), file/line -> physicalLocation, a stable per-rule id slugged from the title (+ guideline prefix for grouping). rules/results serialize as `[]` (never null) when empty, per schema.
- `--format sarif` on `codescan` and `preflight`. The banner is suppressed for machine formats so stdout stays valid JSON/SARIF — this also fixes a pre-existing `codescan --format json` banner leak.
- `preflight --verify --format sarif` errors up front rather than running (and billing) a device flow whose runtime result SARIF can't carry. Use `--format json` for combined static+runtime output.
- README documents the format + an upload-sarif CI example.

## Usage
```yaml
- run: greenlight preflight . --format sarif --output greenlight.sarif
- uses: github/codeql-action/upload-sarif@v3
  with:
    sarif_file: greenlight.sarif
```

Tests validate the SARIF structure, rule dedup, level mapping, locations, and the empty-findings case. Separately reviewed against the OASIS 2.1.0 schema; the one schema issue found (null arrays on empty input) is fixed here.