### PR TITLE
Add .greenlight.yml config (rule enable/disable, severity, ignores)

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,26 @@ All scan commands support:
 --output file.json  # write to file instead of stdout
 ```
 
+## Configuration (`.greenlight.yml`)
+
+Drop a `.greenlight.yml` in your project root to tune the code scan — disable a
+rule, change a rule's severity, or ignore paths:
+
+```yaml
+rules:
+  hardcoded-ipv4:
+    severity: info        # downgrade (info | warn | critical)
+  platform-reference:
+    enabled: false        # turn a rule off
+ignore:
+  - vendor                # skip a directory (anywhere in the tree)
+  - "*.generated.ts"      # skip by filename
+  - src/legacy            # skip a path
+```
+
+It applies to the code scan (`codescan`, and the codescan part of `preflight`).
+Point at a specific file with `codescan --config path/to/.greenlight.yml`.
+
 ## Claude Code Skill
 
 Greenlight works as a Claude Code skill for AI-assisted compliance fixing. Claude runs the scan, reads the output, fixes every issue in your code, and re-runs until GREENLIT.

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/spf13/cobra v1.8.1
 	golang.org/x/term v0.40.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -21,5 +21,7 @@ golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
 golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/term v0.40.0 h1:36e4zGLqU4yhjlmxEaagx2KuYbJq3EwY8K943ZsHcvg=
 golang.org/x/term v0.40.0/go.mod h1:w2P8uVp06p2iyKKuvXIm7N/y0UCRt3UfJTfZ7oOpglM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/cli/codescan.go
+++ b/internal/cli/codescan.go
@@ -17,6 +17,7 @@ var (
 	codescanPath   string
 	codescanFormat string
 	codescanOutput string
+	codescanConfig string
 )
 
 var codescanCmd = &cobra.Command{
@@ -49,7 +50,15 @@ Checks for:
 func init() {
 	codescanCmd.Flags().StringVar(&codescanFormat, "format", "terminal", "output format: terminal, json")
 	codescanCmd.Flags().StringVar(&codescanOutput, "output", "", "write report to file (stdout if omitted)")
+	codescanCmd.Flags().StringVar(&codescanConfig, "config", "", "path to a .greenlight.yml (default: auto-detected in the scanned project)")
 	rootCmd.AddCommand(codescanCmd)
+}
+
+func loadCodescanConfig(path string) (*codescan.Config, error) {
+	if codescanConfig != "" {
+		return codescan.LoadConfigFile(codescanConfig)
+	}
+	return codescan.LoadConfig(path)
 }
 
 func runCodescan(cmd *cobra.Command, args []string) error {
@@ -74,7 +83,11 @@ func runCodescan(cmd *cobra.Command, args []string) error {
 
 	// Run scan
 	start := time.Now()
-	scanner := codescan.NewScanner(path, verbose)
+	cfg, err := loadCodescanConfig(path)
+	if err != nil {
+		return fmt.Errorf("config: %w", err)
+	}
+	scanner := codescan.NewScannerWithConfig(path, verbose, cfg)
 	findings, err := scanner.Scan()
 	if err != nil {
 		return fmt.Errorf("scan failed: %w", err)

--- a/internal/codescan/config.go
+++ b/internal/codescan/config.go
@@ -1,0 +1,202 @@
+package codescan
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Config is the optional .greenlight.yml that tunes the code scan: disable rules,
+// override a rule's severity, or ignore file paths. It applies to the code scan
+// only (the rule engine); the privacy/ipa/metadata scanners are unaffected.
+type Config struct {
+	Rules  map[string]RuleConfig `yaml:"rules"`
+	Ignore []string              `yaml:"ignore"`
+}
+
+// RuleConfig overrides a single rule by id.
+type RuleConfig struct {
+	Enabled  *bool  `yaml:"enabled"`  // nil = default (enabled); false disables the rule
+	Severity string `yaml:"severity"` // "" = default; otherwise info|warn|critical
+}
+
+// configNames are the filenames LoadConfig looks for in the project root.
+var configNames = []string{".greenlight.yml", ".greenlight.yaml"}
+
+// LoadConfig reads .greenlight.yml/.greenlight.yaml from root. It returns
+// (nil, nil) when no config file exists, and validates rule severities/ids.
+func LoadConfig(root string) (*Config, error) {
+	for _, name := range configNames {
+		p := filepath.Join(root, name)
+		data, err := os.ReadFile(p)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, err
+		}
+		cfg, err := decodeConfig(data)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", name, err)
+		}
+		if err := cfg.validate(); err != nil {
+			return nil, fmt.Errorf("%s: %w", name, err)
+		}
+		return cfg, nil
+	}
+	return nil, nil
+}
+
+// LoadConfigFile reads an explicit config path (for a --config flag).
+func LoadConfigFile(p string) (*Config, error) {
+	data, err := os.ReadFile(p)
+	if err != nil {
+		return nil, err
+	}
+	cfg, err := decodeConfig(data)
+	if err != nil {
+		return nil, err
+	}
+	if err := cfg.validate(); err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
+
+// decodeConfig parses YAML with KnownFields(true) so a typo'd key (e.g. `rule:`
+// instead of `rules:`) errors instead of being silently dropped. An empty file
+// decodes to an empty Config.
+func decodeConfig(data []byte) (*Config, error) {
+	var cfg Config
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	if err := dec.Decode(&cfg); err != nil {
+		if errors.Is(err, io.EOF) {
+			return &cfg, nil // empty / comments-only file
+		}
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+func (c *Config) validate() error {
+	rulesByID := map[string]Rule{}
+	for _, r := range AllRules() {
+		if id := ruleIDOf(r); id != "" {
+			rulesByID[id] = r
+		}
+	}
+	for id, rc := range c.Rules {
+		r, ok := rulesByID[id]
+		if !ok {
+			return fmt.Errorf("unknown rule id %q (run 'greenlight codescan' to see rule ids in the output, or check the docs)", id)
+		}
+		if rc.Severity != "" {
+			if _, ok := parseSeverity(rc.Severity); !ok {
+				return fmt.Errorf("rule %q: invalid severity %q (use info, warn, or critical)", id, rc.Severity)
+			}
+			// Only PatternRule carries a single configurable severity; the others
+			// emit per-finding severities, so an override there would be a no-op.
+			if _, ok := r.(*PatternRule); !ok {
+				return fmt.Errorf("rule %q doesn't support a severity override; use enabled: true/false instead", id)
+			}
+		}
+	}
+	return nil
+}
+
+func parseSeverity(s string) (Severity, bool) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "info":
+		return SeverityInfo, true
+	case "warn", "warning":
+		return SeverityWarn, true
+	case "critical":
+		return SeverityCritical, true
+	}
+	return 0, false
+}
+
+// ruleIDOf returns a rule's id across the concrete rule types.
+func ruleIDOf(r Rule) string {
+	switch v := r.(type) {
+	case *PatternRule:
+		return v.id
+	case *PlistKeyRule:
+		return v.id
+	case *ExpoConfigRule:
+		return v.id
+	}
+	return ""
+}
+
+// apply filters/overrides a rule set per config and returns the kept rules.
+func (c *Config) applyRules(rules []Rule) []Rule {
+	if c == nil || len(c.Rules) == 0 {
+		return rules
+	}
+	out := rules[:0]
+	for _, r := range rules {
+		rc, ok := c.Rules[ruleIDOf(r)]
+		if !ok {
+			out = append(out, r)
+			continue
+		}
+		if rc.Enabled != nil && !*rc.Enabled {
+			continue // disabled
+		}
+		if rc.Severity != "" {
+			// Severity override applies to PatternRule; other rule types carry
+			// per-finding severities and are left as-is.
+			if pr, ok := r.(*PatternRule); ok {
+				if sev, ok := parseSeverity(rc.Severity); ok {
+					pr.severity = sev
+				}
+			}
+		}
+		out = append(out, r)
+	}
+	return out
+}
+
+// ignores reports whether a relative path matches any ignore glob. It supports
+// exact globs (path.Match), basename globs like "*.generated.ts", bare directory
+// or segment names ("vendor"), and path prefixes ("src/legacy").
+func (c *Config) ignores(relPath string) bool {
+	if c == nil {
+		return false
+	}
+	rel := filepath.ToSlash(relPath)
+	base := path.Base(rel)
+	for _, g := range c.Ignore {
+		g = filepath.ToSlash(strings.TrimSpace(g))
+		if g == "" {
+			continue
+		}
+		if ok, _ := path.Match(g, rel); ok {
+			return true
+		}
+		if !strings.Contains(g, "/") {
+			if ok, _ := path.Match(g, base); ok {
+				return true
+			}
+			for _, seg := range strings.Split(rel, "/") {
+				if seg == g {
+					return true
+				}
+			}
+		}
+		prefix := strings.TrimSuffix(g, "/")
+		if rel == prefix || strings.HasPrefix(rel, prefix+"/") {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/codescan/config_test.go
+++ b/internal/codescan/config_test.go
@@ -1,0 +1,89 @@
+package codescan
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadConfigAbsent(t *testing.T) {
+	cfg, err := LoadConfig(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg != nil {
+		t.Errorf("expected nil config when no file is present, got %+v", cfg)
+	}
+}
+
+func TestLoadConfigValidation(t *testing.T) {
+	dir := t.TempDir()
+	write := func(body string) {
+		if err := os.WriteFile(filepath.Join(dir, ".greenlight.yml"), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	write("rules:\n  not-a-real-rule:\n    enabled: false\n")
+	if _, err := LoadConfig(dir); err == nil {
+		t.Error("expected an error for an unknown rule id")
+	}
+
+	write("rules:\n  hardcoded-ipv4:\n    severity: bogus\n")
+	if _, err := LoadConfig(dir); err == nil {
+		t.Error("expected an error for an invalid severity")
+	}
+
+	// Severity override on a non-PatternRule (PlistKeyRule) can't be honored.
+	write("rules:\n  missing-privacy-keys:\n    severity: info\n")
+	if _, err := LoadConfig(dir); err == nil {
+		t.Error("expected an error for a severity override on a non-PatternRule")
+	}
+
+	// A typo'd field is rejected (KnownFields), not silently ignored.
+	write("rules:\n  hardcoded-ipv4:\n    enable: false\n") // 'enable', not 'enabled'
+	if _, err := LoadConfig(dir); err == nil {
+		t.Error("expected an error for an unknown field (typo)")
+	}
+
+	write("rules:\n  hardcoded-ipv4:\n    severity: info\nignore:\n  - vendor\n")
+	cfg, err := LoadConfig(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg == nil || cfg.Rules["hardcoded-ipv4"].Severity != "info" || len(cfg.Ignore) != 1 {
+		t.Errorf("unexpected config: %+v", cfg)
+	}
+}
+
+func TestApplyRulesDisableAndOverride(t *testing.T) {
+	disabled := false
+	cfg := &Config{Rules: map[string]RuleConfig{
+		"hardcoded-ipv4":     {Enabled: &disabled},
+		"platform-reference": {Severity: "info"},
+	}}
+
+	for _, r := range cfg.applyRules(AllRules()) {
+		if ruleIDOf(r) == "hardcoded-ipv4" {
+			t.Error("hardcoded-ipv4 should have been disabled (removed)")
+		}
+		if pr, ok := r.(*PatternRule); ok && pr.id == "platform-reference" && pr.severity != SeverityInfo {
+			t.Errorf("platform-reference severity = %v, want INFO", pr.severity)
+		}
+	}
+}
+
+func TestIgnores(t *testing.T) {
+	cfg := &Config{Ignore: []string{"vendor", "*.generated.ts", "src/legacy"}}
+
+	for _, p := range []string{"vendor/Foo.swift", "vendor/deep/Bar.swift", "api.generated.ts", "src/legacy/Old.ts", "src/legacy"} {
+		if !cfg.ignores(p) {
+			t.Errorf("expected %q to be ignored", p)
+		}
+	}
+	for _, p := range []string{"src/App.tsx", "lib/vendored.ts", "x.generated.ts.bak"} {
+		if cfg.ignores(p) {
+			t.Errorf("expected %q NOT to be ignored", p)
+		}
+	}
+}

--- a/internal/codescan/scanner.go
+++ b/internal/codescan/scanner.go
@@ -14,6 +14,7 @@ type Scanner struct {
 	root    string
 	verbose bool
 	rules   []Rule
+	cfg     *Config
 }
 
 // FileContext holds a scanned file and its lines for pattern matching.
@@ -25,11 +26,19 @@ type FileContext struct {
 }
 
 func NewScanner(root string, verbose bool) *Scanner {
+	return NewScannerWithConfig(root, verbose, nil)
+}
+
+// NewScannerWithConfig builds a scanner applying an optional .greenlight.yml
+// (rule enable/disable, severity overrides, path ignores). A nil cfg is the
+// default behavior.
+func NewScannerWithConfig(root string, verbose bool, cfg *Config) *Scanner {
 	s := &Scanner{
 		root:    root,
 		verbose: verbose,
+		cfg:     cfg,
 	}
-	s.rules = AllRules()
+	s.rules = cfg.applyRules(AllRules())
 	return s
 }
 
@@ -169,6 +178,11 @@ func (s *Scanner) collectFiles() ([]FileContext, error) {
 		}
 
 		relPath, _ := filepath.Rel(s.root, path)
+
+		// Honor .greenlight.yml ignore globs.
+		if s.cfg.ignores(relPath) {
+			return nil
+		}
 
 		lines, err := readLines(path)
 		if err != nil {

--- a/internal/preflight/runner.go
+++ b/internal/preflight/runner.go
@@ -1,6 +1,7 @@
 package preflight
 
 import (
+	"fmt"
 	"sync"
 	"time"
 
@@ -54,6 +55,12 @@ func Run(projectPath string, ipaPath string, verbose bool) (*Result, error) {
 		IPAPath:     ipaPath,
 	}
 
+	// Optional .greenlight.yml (rule overrides / ignores) for the code scan.
+	cfg, err := codescan.LoadConfig(projectPath)
+	if err != nil {
+		return nil, fmt.Errorf("config: %w", err)
+	}
+
 	var (
 		mu sync.Mutex
 		wg sync.WaitGroup
@@ -82,7 +89,7 @@ func Run(projectPath string, ipaPath string, verbose bool) (*Result, error) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		scanner := codescan.NewScanner(projectPath, verbose)
+		scanner := codescan.NewScannerWithConfig(projectPath, verbose, cfg)
 		findings, err := scanner.Scan()
 		if err != nil {
 			errs <- err


### PR DESCRIPTION
Tier 2, feature 4 from the scanner review. A `.greenlight.yml` to tune the code scan project-wide — the complement to the per-line `// greenlight:ignore` directive.

## Config
```yaml
rules:
  hardcoded-ipv4:
    severity: info        # downgrade (info | warn | critical)
  platform-reference:
    enabled: false        # turn a rule off
ignore:
  - vendor                # skip a directory (anywhere in the tree)
  - "*.generated.ts"      # skip by filename
  - src/legacy            # skip a path
```

## What
- New `internal/codescan/config.go`: loads `.greenlight.yml`/`.greenlight.yaml` from the project root; applies rule enable/disable, PatternRule severity overrides, and path-ignore globs.
- Strict validation: unknown rule ids, invalid severities, severity overrides on rule types that can't honor them, and typo'd YAML fields (KnownFields) all error clearly rather than silently no-op.
- `Scanner` gains `NewScannerWithConfig`; `codescan` and `preflight` auto-discover the file, and `codescan --config <path>` points at an explicit one.
- Applies to the code scan (the rule engine); the privacy/ipa/metadata scanners are unaffected, documented as such.

## Notes
- Adds `gopkg.in/yaml.v3` (already in the tree as a transitive dep) as a direct require.
- Tests cover load/validate (including the rejection paths), apply (disable + override), and the ignore matcher edge cases. Build/vet/test-race green; separately reviewed (in-place filter safety, no data race, ignore-matcher edges all confirmed).