### PR TITLE
Add GoReleaser release pipeline + Homebrew tap automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: release --clean
+        env:
+          # GITHUB_TOKEN publishes the release on this repo.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # HOMEBREW_TAP_TOKEN is a PAT with write access to RevylAI/homebrew-tap
+          # (the default GITHUB_TOKEN can't push to another repo). Set it in
+          # Settings -> Secrets -> Actions.
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/
+dist/
 *.exe
 .DS_Store
 .env

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,57 @@
+# GoReleaser config — builds, archives, checksums, a GitHub release, and the
+# Homebrew tap formula on every `vX.Y.Z` tag. See .github/workflows/release.yml.
+version: 2
+
+project_name: greenlight
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: greenlight
+    main: ./cmd/greenlight
+    binary: greenlight
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    # Inject the tag into main.version (matches the Makefile's -X main.version).
+    ldflags:
+      - -s -w -X main.version={{ .Version }}
+
+archives:
+  - id: greenlight
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+
+checksum:
+  name_template: "checksums.txt"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^chore:"
+      - "^ci:"
+
+homebrew_casks:
+  - name: greenlight
+    repository:
+      owner: RevylAI
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    homepage: "https://github.com/RevylAI/greenlight"
+    description: "Pre-submission compliance scanner for the Apple App Store"
+    # Strip the quarantine xattr so the unsigned binary runs without a Gatekeeper prompt.
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/greenlight"]
+          end

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,36 @@
+# Releasing
+
+Releases are automated with [GoReleaser](https://goreleaser.com) via
+`.github/workflows/release.yml`. Pushing a `vX.Y.Z` tag builds the binaries
+(macOS + Linux, amd64 + arm64), publishes a GitHub release with checksums, and
+updates the Homebrew tap formula.
+
+## One-time setup
+
+1. **Create the tap repo** `RevylAI/homebrew-tap` (public, empty is fine). This
+   is what backs `brew install revylai/tap/greenlight`.
+2. **Add a secret** `HOMEBREW_TAP_TOKEN` to this repo
+   (Settings → Secrets and variables → Actions): a fine-grained or classic PAT
+   with **contents: write** on `RevylAI/homebrew-tap`. The default `GITHUB_TOKEN`
+   can't push to another repo, which is why this is needed.
+
+## Cutting a release
+
+```bash
+git tag v0.1.0
+git push origin v0.1.0
+```
+
+The workflow does the rest. To dry-run locally first:
+
+```bash
+goreleaser release --snapshot --clean   # builds into ./dist, publishes nothing
+goreleaser check                         # validate the config
+```
+
+After a release, both install paths work:
+
+```bash
+brew install revylai/tap/greenlight
+go install github.com/RevylAI/greenlight/cmd/greenlight@latest
+```


### PR DESCRIPTION
Makes the documented `brew install revylai/tap/greenlight` actually work, and gives `go install` / downloads real versions. Infra only, no code changes.

## What
- `.goreleaser.yml`: cross-compiles macOS + Linux (amd64 + arm64), injects the tag into `main.version`, builds archives + checksums, and updates the Homebrew tap formula (`homebrew_casks` -> RevylAI/homebrew-tap). `goreleaser check` passes clean; a local snapshot builds all four targets and `greenlight version` reports the injected version.
- `.github/workflows/release.yml`: runs GoReleaser on a `vX.Y.Z` tag push.
- `RELEASING.md`: the runbook.
- gitignore `dist/`.

## Activation (two manual steps, see RELEASING.md)
1. Create the `RevylAI/homebrew-tap` repo (public, empty is fine).
2. Add a `HOMEBREW_TAP_TOKEN` secret (PAT with contents:write on the tap repo) — the default GITHUB_TOKEN can't push to another repo.

Then `git tag v0.1.0 && git push origin v0.1.0` cuts the first release.