### PR TITLE
Tag greenlight signup CTA with UTM params

### DIFF
--- a/internal/revyl/client.go
+++ b/internal/revyl/client.go
@@ -19,7 +19,7 @@ import (
 // Onboarding constants for the Revyl activation funnel — surfaced when a
 // greenlight user reaches the runtime tier without a Revyl account.
 const (
-	SignupURL  = "https://app.revyl.ai/signup"
+	SignupURL  = "https://app.revyl.ai/signup?utm_source=greenlight&utm_medium=cli&utm_campaign=verify"
 	InstallCmd = "curl -fsSL https://revyl.com/install.sh | sh"
 	LoginCmd   = "revyl auth login"
 )


### PR DESCRIPTION
Adds UTM params to the Revyl signup link shown in the runtime-tier CTA (when a user runs verify without a Revyl account):

`https://app.revyl.ai/signup?utm_source=greenlight&utm_medium=cli&utm_campaign=verify`

- Display-only: SignupURL is just printed at two CTA call sites, never parsed or matched. No behavior change.
- Lets us attribute greenlight->Revyl signups in PostHog (filter signup_utm_source = greenlight).
- Link points straight at app.revyl.ai, so the app-side first-touch util captures it directly.

build + vet + tests green on the touched packages.