### PR TITLE
Fix swapped plugin.json and marketplace.json manifests

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,26 +1,28 @@
 {
   "name": "greenlight",
-  "title": "Greenlight — App Store Pre-Submission Scanner",
-  "description": "Run ALL App Store compliance checks in one command — code patterns, privacy manifests, IPA binaries, metadata. Catches rejections before you submit. Claude Code integration: run, fix, re-run until GREENLIT.",
-  "author": "revylai",
-  "version": "0.1.0",
-  "category": "compliance",
-  "icon": "shield-check",
-  "install": {
-    "plugin": "greenlight@greenlight"
+  "owner": {
+    "name": "revylai"
   },
-  "triggers": [
-    "app store review",
-    "app store rejection",
-    "app store compliance",
-    "app store guidelines",
-    "submit to app store",
-    "ios submission",
-    "app review preparation",
-    "preflight check",
-    "pre-submission scan",
-    "greenlight",
-    "privacy manifest",
-    "app store ready"
+  "description": "Greenlight — Apple App Store pre-submission compliance scanner.",
+  "plugins": [
+    {
+      "name": "greenlight",
+      "source": "./",
+      "description": "Run ALL App Store compliance checks in one command — code patterns, privacy manifests, IPA binaries, metadata. Catches rejections before you submit.",
+      "category": "compliance",
+      "tags": [
+        "apple",
+        "app-store",
+        "review",
+        "guidelines",
+        "ios",
+        "swift",
+        "react-native",
+        "expo",
+        "rejection",
+        "compliance"
+      ],
+      "strict": true
+    }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,26 +1,27 @@
 {
   "name": "greenlight",
-  "owner": {
-    "name": "revylai"
+  "displayName": "Greenlight — App Store Pre-Submission Scanner",
+  "description": "Run ALL App Store compliance checks in one command — code patterns, privacy manifests, IPA binaries, metadata. Catches rejections before you submit. Claude Code integration: run, fix, re-run until GREENLIT.",
+  "version": "0.1.0",
+  "author": {
+    "name": "revylai",
+    "url": "https://revyl.com"
   },
-  "plugins": [
-    {
-      "name": "greenlight",
-      "source": "../",
-      "category": "compliance",
-      "tags": [
-        "apple",
-        "app-store",
-        "review",
-        "guidelines",
-        "ios",
-        "swift",
-        "react-native",
-        "expo",
-        "rejection",
-        "compliance"
-      ],
-      "strict": true
-    }
+  "homepage": "https://github.com/RevylAI/greenlight",
+  "repository": "https://github.com/RevylAI/greenlight",
+  "license": "MIT",
+  "keywords": [
+    "app store review",
+    "app store rejection",
+    "app store compliance",
+    "app store guidelines",
+    "submit to app store",
+    "ios submission",
+    "app review preparation",
+    "preflight check",
+    "pre-submission scan",
+    "greenlight",
+    "privacy manifest",
+    "app store ready"
   ]
 }


### PR DESCRIPTION
Closes #15.

The two manifests had their contents swapped, so installing from the marketplace failed with `source type your Claude Code version does not support`.

What changed:
- `marketplace.json` is now the `owner` + `plugins[]` catalog (the shape Claude Code expects when reading a marketplace).
- `plugin.json` is now the single-plugin manifest (`author` as an object, former `triggers` moved to `keywords`).
- Plugin `source` is `"./"`. The old value `"../"` points outside the marketplace root, which the schema disallows; the plugin lives at the repo root.

Verified with `claude plugin validate . --strict` (passes).