### PR TITLE
fix(playscan): drop redundant clause from the Play Billing fix line

### DIFF
--- a/internal/playscan/rules.go
+++ b/internal/playscan/rules.go
@@ -166,7 +166,7 @@ func rulePlayBillingVersion(c *ruleContext) []Finding {
 			"Play Billing Library 7 and below lose support and updates using them can no longer be published. %s. "+
 				"There is no direct 7-to-9 upgrade: the version 8 migration has to be done first.",
 			deadlinePhrase(billingDeadline)),
-		Fix:  fmt.Sprintf("Upgrade com.android.billingclient:billing to %d.x or higher, migrating through 8 if you are on 7.", minSupportedBillingMajor),
+		Fix:  fmt.Sprintf("Upgrade com.android.billingclient:billing to %d.x or higher.", minSupportedBillingMajor),
 		Doc:  docBillingDeprecat,
 		File: c.gradle.BillingFile,
 		Line: c.gradle.BillingLine,


### PR DESCRIPTION
Copy-only. Caught while scanning purpose-built Android test apps.

The Play Billing finding's fix line read:

> Upgrade com.android.billingclient:billing to 8.x or higher, migrating through 8 if you are on 7.

That is circular, and the no-direct-7-to-9 point is already made in the finding's detail text. The fix line now carries only the action:

> Upgrade com.android.billingclient:billing to 8.x or higher.

No behaviour change, no test changes needed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing remediation text only; scan rules and billing version checks are unchanged.
> 
> **Overview**
> **Copy-only change** to the Play Billing Library scan finding in `rulePlayBillingVersion`.
> 
> The **Fix** field no longer appends “migrating through 8 if you are on 7,” which duplicated the detail text and read circularly (“upgrade to 8.x … migrating through 8”). It now only says to upgrade `com.android.billingclient:billing` to **8.x or higher** (via `minSupportedBillingMajor`). **Detail** text is unchanged and still explains the no direct 7→9 path.
> 
> No rule logic, severity, or detection behaviour changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b8342c2386d7ffea7c718453931c7c5001ecce8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->