### PR TITLE
fix(playscan): match Android XR by namespace instead of invented feature names

### DIFF
--- a/internal/playscan/manifest.go
+++ b/internal/playscan/manifest.go
@@ -63,13 +63,29 @@ const (
 
 // featureFormFactors maps the <uses-feature> declaration that puts an app on a
 // non-phone Play track to that form factor.
+//
+// Every name here was read back from PackageManager's constant pool in
+// android.jar on android-34, -35 and -36, which all agree.
 var featureFormFactors = map[string]FormFactor{
-	"android.hardware.type.watch":       FormFactorWear,
-	"android.hardware.type.television":  FormFactorTV,
-	"android.software.leanback":         FormFactorTV,
-	"android.hardware.type.automotive":  FormFactorAutomotive,
-	"android.software.xr.immersive":     FormFactorXR,
-	"android.hardware.xr.head_tracking": FormFactorXR,
+	"android.hardware.type.watch":      FormFactorWear,
+	"android.hardware.type.television": FormFactorTV,
+	"android.software.leanback":        FormFactorTV,
+	"android.hardware.type.automotive": FormFactorAutomotive,
+}
+
+// xrFeaturePrefixes cover Android XR, which is matched by namespace rather than
+// by exact name.
+//
+// No XR feature constant appears in any android.jar shipped for API 34 to 36,
+// so an exact name could not be verified the way the ones above were. Guessing
+// one is how this rule broke before: two invented names meant no XR app ever
+// matched, and XR packages kept getting the phone track's blocking finding.
+// Matching the namespace is correct for every current XR feature
+// (android.software.xr.api.spatial, android.software.xr.api.openxr, the
+// android.hardware.xr.* inputs) and for ones added later.
+var xrFeaturePrefixes = []string{
+	"android.software.xr.",
+	"android.hardware.xr.",
 }
 
 // FormFactor reports the non-phone form factor this manifest declares, or
@@ -85,6 +101,11 @@ func (m *Manifest) FormFactor() FormFactor {
 		}
 		if ff, ok := featureFormFactors[f.Name]; ok {
 			return ff
+		}
+		for _, prefix := range xrFeaturePrefixes {
+			if strings.HasPrefix(f.Name, prefix) {
+				return FormFactorXR
+			}
 		}
 	}
 	return FormFactorPhone

--- a/internal/playscan/rules_test.go
+++ b/internal/playscan/rules_test.go
@@ -15,7 +15,9 @@ func TestTargetAPILevelRespectsFormFactor(t *testing.T) {
 		{"wear", "android.hardware.type.watch", FormFactorWear},
 		{"tv", "android.software.leanback", FormFactorTV},
 		{"automotive", "android.hardware.type.automotive", FormFactorAutomotive},
-		{"xr", "android.software.xr.immersive", FormFactorXR},
+		{"xr spatial", "android.software.xr.api.spatial", FormFactorXR},
+		{"xr openxr", "android.software.xr.api.openxr", FormFactorXR},
+		{"xr hardware input", "android.hardware.xr.input.controller", FormFactorXR},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -69,5 +71,47 @@ func TestTargetAPILevelFormFactorCleanWhenCurrent(t *testing.T) {
 	}
 	if findings := ruleTargetAPILevel(c); len(findings) != 0 {
 		t.Errorf("want no findings, got %d: %s", len(findings), findings[0].Title)
+	}
+}
+
+// XR is matched by namespace, not by an exact constant name. The rule shipped
+// with two invented names (android.software.xr.immersive,
+// android.hardware.xr.head_tracking) that no real XR app declares, so no XR
+// package ever matched and they kept getting the phone track's blocking
+// finding. No XR constant appears in android.jar for API 34-36, so the
+// namespace is what can actually be relied on.
+func TestFormFactorMatchesXRByNamespace(t *testing.T) {
+	xr := []string{
+		"android.software.xr.api.spatial",
+		"android.software.xr.api.openxr",
+		"android.hardware.xr.input.controller",
+		"android.software.xr.something.added.later",
+	}
+	for _, name := range xr {
+		m := &Manifest{UsesFeatures: []UsesFeature{{Name: name}}}
+		if got := m.FormFactor(); got != FormFactorXR {
+			t.Errorf("%s: FormFactor = %q, want %q", name, got, FormFactorXR)
+		}
+	}
+
+	// The namespace must not swallow unrelated features that merely contain
+	// "xr", nor an XR feature the app says it does not require.
+	notXR := []string{
+		"android.hardware.camera",
+		"android.software.xrated", // not the xr namespace: no dot after xr
+		"com.example.xr.custom",
+	}
+	for _, name := range notXR {
+		m := &Manifest{UsesFeatures: []UsesFeature{{Name: name}}}
+		if got := m.FormFactor(); got != FormFactorPhone {
+			t.Errorf("%s: FormFactor = %q, want phone", name, got)
+		}
+	}
+
+	optional := &Manifest{UsesFeatures: []UsesFeature{
+		{Name: "android.software.xr.api.spatial", Required: "false"},
+	}}
+	if got := optional.FormFactor(); got != FormFactorPhone {
+		t.Errorf("optional XR feature: FormFactor = %q, want phone", got)
 	}
 }


### PR DESCRIPTION
Fixes the issue Cursor Bugbot reported on #22, which was correct and which I merged without reading.

`featureFormFactors` mapped Android XR to `android.software.xr.immersive` and `android.hardware.xr.head_tracking`. Neither is a real feature constant, so no XR app ever matched and XR packages kept getting the phone track's blocking target API finding. That is the exact false CRITICAL the form-factor work was supposed to remove. The regression test used the same invented names, so it passed while the rule did nothing.

No XR constant appears in `PackageManager`'s constant pool in `android.jar` for API 34, 35 or 36, so an exact name cannot be verified the way the others were. Rather than replace one unverifiable guess with another, XR is matched on its namespace: a required feature under `android.software.xr.` or `android.hardware.xr.` marks the app as XR. That covers `api.spatial`, `api.openxr`, the `hardware.xr.*` inputs, and anything added later.

The other four names are unchanged and were confirmed by reading `PackageManager`'s constant pool out of `android.jar` on all three platform versions: `android.hardware.type.watch`, `android.hardware.type.television`, `android.software.leanback`, `android.hardware.type.automotive`.

Tests now use real XR feature names, and cover the namespace boundary (`android.software.xrated` and `com.example.xr.custom` stay on the phone track) and `required="false"`. The new test was confirmed to fail against the shipped names.

Verified end to end against an aapt2-linked XR APK: targetSdk 33 with a required `android.software.xr.api.spatial` feature now reports `WARN ... this is a Android XR app` instead of `CRITICAL`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized playscan manifest classification fix with expanded tests; no auth, security, or data-path changes.
> 
> **Overview**
> **Fixes false CRITICAL target-API findings on real Android XR apps** by detecting XR from required `<uses-feature>` names under `android.software.xr.` or `android.hardware.xr.` instead of two exact strings that never appear in real manifests or `android.jar` (API 34–36).
> 
> `Manifest.FormFactor()` now checks those prefixes after the verified Wear/TV/Automotive map, so XR apps get the non-phone **WARN** path in `ruleTargetAPILevel` rather than the phone track’s blocking rule. Wear, TV, and Automotive mappings are unchanged aside from comment/formatting.
> 
> Tests switch to real XR feature names, add `TestFormFactorMatchesXRByNamespace` (forward-compatible names, non-matches like `android.software.xrated`, and `required="false"`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5c2cf99d8dd127b77aa6c0bec08a8d6dbba2573. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->