### PR TITLE
chore(release): prep v0.2.0, the first release with Google Play support

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,12 +3,12 @@
   "owner": {
     "name": "revylai"
   },
-  "description": "Greenlight — Apple App Store pre-submission compliance scanner.",
+  "description": "Greenlight \u2014 Apple App Store and Google Play pre-submission compliance scanner.",
   "plugins": [
     {
       "name": "greenlight",
       "source": "./",
-      "description": "Run ALL App Store compliance checks in one command — code patterns, privacy manifests, IPA binaries, metadata. Catches rejections before you submit.",
+      "description": "Run every App Store and Google Play compliance check in one command: code patterns, privacy manifests, Android manifests and Gradle, IPA/APK/AAB binaries, metadata. Catches rejections before you submit.",
       "category": "compliance",
       "tags": [
         "apple",
@@ -20,7 +20,12 @@
         "react-native",
         "expo",
         "rejection",
-        "compliance"
+        "compliance",
+        "android",
+        "google-play",
+        "play-policy",
+        "gradle",
+        "aab"
       ],
       "strict": true
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "greenlight",
-  "displayName": "Greenlight — App Store Pre-Submission Scanner",
-  "description": "Run ALL App Store compliance checks in one command — code patterns, privacy manifests, IPA binaries, metadata. Catches rejections before you submit. Claude Code integration: run, fix, re-run until GREENLIT.",
-  "version": "0.1.0",
+  "displayName": "Greenlight \u2014 App Store & Google Play Pre-Submission Scanner",
+  "description": "Run every App Store and Google Play compliance check in one command: code patterns, privacy manifests, Android manifests and Gradle, IPA/APK/AAB binaries, metadata. Catches rejections before you submit. Claude Code integration: run, fix, re-run until GREENLIT.",
+  "version": "0.2.0",
   "author": {
     "name": "revylai",
     "url": "https://revyl.com"
@@ -22,6 +22,12 @@
     "pre-submission scan",
     "greenlight",
     "privacy manifest",
-    "app store ready"
+    "app store ready",
+    "android",
+    "google play",
+    "play policy",
+    "target api level",
+    "apk",
+    "aab"
   ]
 }

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -31,6 +31,14 @@ archives:
 checksum:
   name_template: "checksums.txt"
 
+# Pin the target repo rather than letting GoReleaser infer it from the git
+# remote. A contributor's fork is a perfectly ordinary remote, and the inferred
+# value ends up baked into the Homebrew cask's download URLs.
+release:
+  github:
+    owner: RevylAI
+    name: greenlight
+
 changelog:
   sort: asc
   filters:
@@ -47,7 +55,7 @@ homebrew_casks:
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
     homepage: "https://github.com/RevylAI/greenlight"
-    description: "Pre-submission compliance scanner for the Apple App Store"
+    description: "Pre-submission compliance scanner for the Apple App Store and Google Play"
     # Strip the quarantine xattr so the unsigned binary runs without a Gatekeeper prompt.
     hooks:
       post:

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: greenlight
 description: >
-  Pre-submission compliance scanner for Apple App Store. Use this skill when reviewing
-  iOS, macOS, tvOS, watchOS, or visionOS app code (Swift, Objective-C, React Native, Expo)
-  to identify potential App Store rejection risks before submission. Triggers on tasks involving
-  app review preparation, compliance checking, App Store submission readiness, or when a user
-  asks about App Store guidelines.
+  Pre-submission compliance scanner for the Apple App Store and Google Play. Use this skill
+  when reviewing iOS, macOS, tvOS, watchOS, visionOS, or Android app code (Swift, Objective-C,
+  Kotlin, Java, React Native, Expo) to identify store rejection risks before submission, including
+  Android manifest and Gradle policy checks and built APK/AAB inspection. Triggers on tasks
+  involving app review preparation, compliance checking, App Store or Play submission readiness,
+  target API level deadlines, restricted permissions, or when a user asks about App Store
+  guidelines or Google Play Developer Program Policies.
 ---
 
 # Greenlight — App Store Pre-Submission Scanner

--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,7 @@
 {
-  "version": "0.1.0",
+  "version": "0.2.0",
   "name": "greenlight",
-  "description": "Pre-submission compliance scanner for Apple App Store",
+  "description": "Pre-submission compliance scanner for the Apple App Store and Google Play",
   "organization": {
     "name": "Revyl",
     "url": "https://revyl.com"
@@ -13,10 +13,27 @@
     "https://developer.apple.com/documentation/apptrackingtransparency",
     "https://developer.apple.com/documentation/localauthentication",
     "https://developer.apple.com/documentation/networkextension/nevpnmanager",
-    "https://developer.apple.com/help/app-store-connect/"
+    "https://developer.apple.com/help/app-store-connect/",
+    "https://support.google.com/googleplay/android-developer/answer/16810878",
+    "https://developer.android.com/google/play/requirements/target-sdk"
   ],
   "keywords": [
-    "apple", "app-store", "review", "guidelines", "ios", "swift",
-    "react-native", "expo", "compliance", "rejection", "preflight"
+    "apple",
+    "app-store",
+    "review",
+    "guidelines",
+    "ios",
+    "swift",
+    "react-native",
+    "expo",
+    "compliance",
+    "rejection",
+    "preflight",
+    "android",
+    "google-play",
+    "playscan",
+    "gradle",
+    "aab",
+    "apk"
   ]
 }


### PR DESCRIPTION
`playscan` shipped in #17 but has never been in a release. v0.1.0 predates it, so Homebrew and `go install` users are still on an Apple-only binary. This is the prep for the tag that fixes that.

- Bump `metadata.json` and `.claude-plugin/plugin.json` to 0.2.0.
- The packaging descriptions all still said "Apple App Store" only. That string becomes the Homebrew cask description and is what the plugin marketplace and skill router read, so it is corrected in `.goreleaser.yml`, `metadata.json`, both `.claude-plugin` manifests, and `SKILL.md`'s frontmatter (which now also mentions Kotlin/Java, APK/AAB, target API deadlines and restricted permissions, so Android tasks route to the skill at all).
- Pin the release repo in `.goreleaser.yml`. GoReleaser otherwise infers the owner from the git remote, and a local dry-run baked a contributor fork's URL into the generated cask. Verified fixed.

**GoReleaser has never actually run for this project.** It landed in #12, after the v0.1.0 tag, and that release carries no binary assets, so the tag push will be its first real exercise. Validated as far as possible locally: `goreleaser check` passes, and `goreleaser release --snapshot` builds all four targets, writes the cask, and produces a binary with the `playscan` command.

**Known follow-up the tag will not fix:** the tap has `Formula/greenlight.rb` pinned to v0.1.0, while this config publishes `homebrew_casks` → `Casks/greenlight.rb`. Homebrew prefers a formula over a cask of the same name, so the stale formula must be removed from the tap once the release publishes, or `brew install revylai/tap/greenlight` keeps resolving to v0.1.0.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging, version, and documentation strings only; no application or scanner logic changes.
> 
> **Overview**
> Prepares **v0.2.0**, the first release that ships existing Google Play (`playscan`) support to Homebrew and `go install` users who are still on the Apple-only **v0.1.0** artifacts.
> 
> **Version and positioning:** Bumps `metadata.json` and `.claude-plugin/plugin.json` to **0.2.0** and rewrites descriptions, display name, keywords, and marketplace tags so packaging and Claude routing reflect **App Store and Google Play** (manifest/Gradle, APK/AAB, Play policy) instead of Apple-only copy.
> 
> **Release tooling:** Pins GoReleaser’s GitHub `release` target to **RevylAI/greenlight** so fork remotes cannot leak into generated Homebrew cask download URLs; updates the cask description to match the dual-store messaging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 405ea47b2053620f5f0e204c9190c1349c4c6d8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->