### PR TITLE
docs: describe how the Homebrew tap is actually updated

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,30 +2,24 @@
 
 Releases are automated with [GoReleaser](https://goreleaser.com) via
 `.github/workflows/release.yml`. Pushing a `vX.Y.Z` tag builds the binaries
-(macOS + Linux, amd64 + arm64), publishes a GitHub release with checksums, and
-updates the Homebrew tap formula.
-
-## One-time setup
-
-1. **Create the tap repo** `RevylAI/homebrew-tap` (public, empty is fine). This
-   is what backs `brew install revylai/tap/greenlight`.
-2. **Add a secret** `HOMEBREW_TAP_TOKEN` to this repo
-   (Settings → Secrets and variables → Actions): a fine-grained or classic PAT
-   with **contents: write** on `RevylAI/homebrew-tap`. The default `GITHUB_TOKEN`
-   can't push to another repo, which is why this is needed.
+(macOS + Linux, amd64 + arm64) and publishes a GitHub release with checksums.
 
 ## Cutting a release
 
 ```bash
-git tag v0.1.0
-git push origin v0.1.0
+git tag -a v0.2.0 -m "v0.2.0 — what changed"
+git push origin v0.2.0
 ```
 
-The workflow does the rest. To dry-run locally first:
+Bump `version` in `metadata.json` and `.claude-plugin/plugin.json` first, in a
+normal PR. The tag should point at a commit where those already read the new
+number.
+
+To dry-run locally:
 
 ```bash
+goreleaser check                        # validate the config
 goreleaser release --snapshot --clean   # builds into ./dist, publishes nothing
-goreleaser check                         # validate the config
 ```
 
 After a release, both install paths work:
@@ -34,3 +28,46 @@ After a release, both install paths work:
 brew install revylai/tap/greenlight
 go install github.com/RevylAI/greenlight/cmd/greenlight@latest
 ```
+
+## How the Homebrew tap is updated
+
+`brew install revylai/tap/greenlight` is backed by
+[`RevylAI/homebrew-tap`](https://github.com/RevylAI/homebrew-tap).
+
+The `homebrew_casks` block in `.goreleaser.yml` wants to push the cask there
+during the release, which needs a `HOMEBREW_TAP_TOKEN` secret, because a
+workflow's built-in `GITHUB_TOKEN` cannot write to a different repository. That
+secret has never been set, and creating it needs **admin** on this repo. The
+v0.2.0 release published its binaries fine and then failed on that step with
+`401 Bad credentials`.
+
+So the tap updates itself instead. `.github/workflows/update-cask.yml` in the
+tap repo polls this repo's releases hourly, regenerates `Casks/greenlight.rb`,
+and commits with its own `GITHUB_TOKEN`. Reading a public repo's releases needs
+no credentials and a workflow can always write to its own repo, so that path
+needs no secret and no admin. It can also be run on demand from the tap's
+Actions tab if you don't want to wait for the next hour.
+
+Nothing needs to be done during a release. Confirm the tap picked it up:
+
+```bash
+brew update && brew info --cask revylai/tap/greenlight
+```
+
+If `HOMEBREW_TAP_TOKEN` is ever configured, both paths can coexist: the tap
+workflow generates output byte-identical to GoReleaser's template, so whichever
+runs second is a no-op rather than a revert.
+
+### Gotchas worth knowing
+
+- **The tap serves a cask, not a formula.** GoReleaser's `brews` output is
+  deprecated and now fails `goreleaser check`. Homebrew prefers a formula over a
+  cask of the same name, so a leftover `Formula/greenlight.rb` will silently keep
+  winning and serving an old version. There must only be one.
+- **Don't hash locally built archives.** The builds are not byte-reproducible, so
+  a cask generated from a local `goreleaser release --snapshot` carries hashes
+  that do not match the published artifacts, and every install fails checksum
+  verification. Always take hashes from the release's `checksums.txt`.
+- **GoReleaser infers the repo from the git remote.** Running a dry-run on a
+  fork bakes the fork's download URLs into the generated cask. `.goreleaser.yml`
+  pins `release.github` to `RevylAI/greenlight` to prevent that.


### PR DESCRIPTION
`RELEASING.md` documented a `HOMEBREW_TAP_TOKEN` setup step that was never completed and cannot be completed without admin on this repo. The v0.2.0 release published its binaries fine and then failed on the cask step with `401 Bad credentials`.

The tap now updates itself instead: [a workflow there](https://github.com/RevylAI/homebrew-tap/blob/main/.github/workflows/update-cask.yml) polls this repo's public releases hourly, regenerates `Casks/greenlight.rb` from the published `checksums.txt`, and commits with its own `GITHUB_TOKEN`. Reading a public repo's releases needs no credentials and a workflow can always write to its own repo, so that path needs no secret and no admin. Verified end to end: the commit step ran, the bot pushed, and `brew install revylai/tap/greenlight` now yields 0.2.0 with `playscan`.

Also records the three things that cost time working this out:

- The tap serves a **cask**, and a leftover `Formula/greenlight.rb` silently outranks it (that is why the tap kept serving v0.1.0). GoReleaser's `brews` output is deprecated and now fails `goreleaser check`.
- Locally built archives are **not byte-reproducible**, so a cask generated from `--snapshot` carries hashes that fail verification on every install. Hashes must come from the release's `checksums.txt`.
- GoReleaser **infers the repo from the git remote**, so a dry-run on a fork bakes the fork's URLs into the cask. Now pinned.

If `HOMEBREW_TAP_TOKEN` is ever configured, both paths coexist: the tap workflow emits output byte-identical to GoReleaser's template, so whichever runs second is a no-op rather than a revert.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, auth, or release workflow code modifications in this diff.
> 
> **Overview**
> **Rewrites `RELEASING.md`** so release docs match how installs actually work today, instead of assuming GoReleaser pushes the tap with `HOMEBREW_TAP_TOKEN`.
> 
> The **one-time `HOMEBREW_TAP_TOKEN` setup is removed** as a required step. Releases are described as tag-driven GoReleaser builds that publish GitHub binaries and checksums only. **Cutting a release** now tells you to bump `version` in `metadata.json` and `.claude-plugin/plugin.json` in a normal PR before tagging, uses an annotated tag example (`v0.2.0`), and puts `goreleaser check` before the snapshot dry-run.
> 
> A new **“How the Homebrew tap is updated”** section explains why the in-repo `homebrew_casks` push failed (`401` without admin-configured `HOMEBREW_TAP_TOKEN`), that **`RevylAI/homebrew-tap`** updates itself via an hourly workflow that regenerates `Casks/greenlight.rb` from public releases, and how to verify with `brew update` / `brew info --cask`. It notes optional coexistence if the token is ever added.
> 
> **“Gotchas worth knowing”** adds operational pitfalls: **cask vs formula** (leftover `Formula/greenlight.rb` wins), **checksums must come from release `checksums.txt`** (not local `--snapshot` builds), and **GoReleaser repo inference on forks** (doc references pinning `release.github` in `.goreleaser.yml`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 372a9ecc4a2cadf22ed9f773331a66f1a5913857. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->